### PR TITLE
[v2] feat: 관리자 쿠키 기반 인증 구축

### DIFF
--- a/components/auth/AdminLoginForm.jsx
+++ b/components/auth/AdminLoginForm.jsx
@@ -5,6 +5,8 @@ import {
   GoogleAuthProvider,
   signInWithPopup,
 } from "firebase/auth";
+import { setCookie } from "nookies";
+
 import { auth } from "@/lib/firebase";
 import ErrorMessage from "@/components/auth/ErrorMessage";
 import { FcGoogle } from "react-icons/fc";
@@ -43,7 +45,21 @@ export default function AdminLoginForm({ errorMessage }) {
     setPasswordMatchError("");
 
     try {
-      await signInWithEmailAndPassword(auth, email, password);
+      const userCredential = await signInWithEmailAndPassword(
+        auth,
+        email,
+        password
+      );
+      const token = await userCredential.user.getIdToken();
+
+      await fetch("/api/admin/login", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ token }),
+      });
+
       router.push("/admin");
     } catch (err) {
       // 외부 errorMessage가 없을 때만 setError 실행

--- a/lib/firebaseAdmin.js
+++ b/lib/firebaseAdmin.js
@@ -10,6 +10,7 @@ if (!admin.apps.length) {
   });
 }
 
+const adminAuth = admin.auth();
 const db = admin.firestore();
 
-export { db };
+export { adminAuth, db };

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,13 +12,14 @@
         "firebase": "^11.6.0",
         "firebase-admin": "^13.2.0",
         "next": "14.1.0",
+        "nookies": "^2.5.2",
         "react": "^18",
         "react-dom": "^18",
         "react-icons": "^5.5.0"
       },
       "devDependencies": {
         "autoprefixer": "^10.4.21",
-        "eslint": "^8",
+        "eslint": "8.57.1",
         "eslint-config-next": "14.1.0",
         "postcss": "^8.5.3",
         "tailwindcss": "^3.4.1"
@@ -2663,6 +2664,15 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
+      "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -5682,6 +5692,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/nookies": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/nookies/-/nookies-2.5.2.tgz",
+      "integrity": "sha512-x0TRSaosAEonNKyCrShoUaJ5rrT5KHRNZ5DwPCuizjgrnkpE5DRf3VL7AyyQin4htict92X1EQ7ejDbaHDVdYA==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^0.4.1",
+        "set-cookie-parser": "^2.4.6"
+      }
+    },
     "node_modules/normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -6659,6 +6679,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
+      "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
+      "license": "MIT"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -13,13 +13,14 @@
     "firebase": "^11.6.0",
     "firebase-admin": "^13.2.0",
     "next": "14.1.0",
+    "nookies": "^2.5.2",
     "react": "^18",
     "react-dom": "^18",
     "react-icons": "^5.5.0"
   },
   "devDependencies": {
     "autoprefixer": "^10.4.21",
-    "eslint": "^8",
+    "eslint": "8.57.1",
     "eslint-config-next": "14.1.0",
     "postcss": "^8.5.3",
     "tailwindcss": "^3.4.1"

--- a/pages/api/admin/login.js
+++ b/pages/api/admin/login.js
@@ -1,0 +1,32 @@
+import { setCookie } from "nookies";
+import { adminAuth } from "@/lib/firebaseAdmin"; // Firebase Admin SDK 세팅
+
+export default async function createAdminSession(req, res) {
+  if (req.method !== "POST") {
+    return res.status(405).end("허용되지 않은 메서드입니다.");
+  }
+
+  const { token } = req.body;
+
+  if (!token) {
+    return res.status(400).json({ message: "토큰이 제공되지 않았습니다." });
+  }
+
+  try {
+    // 토큰 검증
+    const decoded = await adminAuth.verifyIdToken(token);
+
+    // HttpOnly 쿠키 저장
+    setCookie({ res }, "token", token, {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === "production",
+      sameSite: "strict",
+      path: "/",
+    });
+
+    return res.status(200).json({ message: "로그인에 성공했습니다." });
+  } catch (error) {
+    console.error("토큰 검증 실패:", error);
+    return res.status(401).json({ message: "유효하지 않은 토큰입니다." });
+  }
+}


### PR DESCRIPTION
LoneLeap v2 관리자 인증 방식을 쿠키 기반 인증으로 변경했습니다.
기존 클라이언트 측 인증 대신 서버 API를 통해 HttpOnly 쿠키를 설정합니다.

## 주요 변경 사항
- AdminLoginForm 수정: 로그인 성공 후 토큰을 서버 API에 전달하도록 변경
- 서버 API(`/api/admin/login`) 추가: 토큰 검증 및 HttpOnly 쿠키 저장
- firebaseAdmin 설정 보완: adminAuth 객체 추가 및 export

## 테스트 완료 항목
- 정상 로그인 시 HttpOnly 쿠키(`token`)가 저장되는지 확인
- 서버에서 토큰 검증이 정상적으로 동작하는지 확인
- 로그인 실패 시 오류 메시지가 정상적으로 출력되는지 확인
- 세션 유지 상태 확인 (새로고침 후에도 쿠키 존재 확인)