### PR TITLE
feat: 관리자 인증 예외처리 및 세션 만료 대응 개선

### DIFF
--- a/components/auth/AdminLoginForm.jsx
+++ b/components/auth/AdminLoginForm.jsx
@@ -5,7 +5,6 @@ import {
   GoogleAuthProvider,
   signInWithPopup,
 } from "firebase/auth";
-import { setCookie } from "nookies";
 
 import { auth } from "@/lib/firebase";
 import ErrorMessage from "@/components/auth/ErrorMessage";
@@ -60,6 +59,7 @@ export default function AdminLoginForm({ errorMessage }) {
         body: JSON.stringify({ token }),
       });
 
+      localStorage.setItem("sessionStart", new Date().toISOString());
       router.push("/admin");
     } catch (err) {
       // 외부 errorMessage가 없을 때만 setError 실행
@@ -104,6 +104,7 @@ export default function AdminLoginForm({ errorMessage }) {
         body: JSON.stringify({ token }),
       });
 
+      localStorage.setItem("sessionStart", new Date().toISOString());
       router.push("/admin"); // 세션 세팅 완료 후 /admin 이동
     } catch (err) {
       const code = err?.code || "";

--- a/components/auth/AdminLoginForm.jsx
+++ b/components/auth/AdminLoginForm.jsx
@@ -92,8 +92,19 @@ export default function AdminLoginForm({ errorMessage }) {
     setError("");
     try {
       const provider = new GoogleAuthProvider();
-      await signInWithPopup(auth, provider);
-      router.push("/admin");
+      const result = await signInWithPopup(auth, provider); // 1번만 로그인
+      const token = await result.user.getIdToken(); // 토큰 발급
+
+      await fetch("/api/admin/login", {
+        // 서버에 토큰 전송
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ token }),
+      });
+
+      router.push("/admin"); // 세션 세팅 완료 후 /admin 이동
     } catch (err) {
       const code = err?.code || "";
       switch (code) {

--- a/components/auth/AdminProtectedRoute.jsx
+++ b/components/auth/AdminProtectedRoute.jsx
@@ -20,9 +20,9 @@ export default function AdminProtectedRoute({ children }) {
           router.replace(
             {
               pathname: "/admin/login",
-              query: { error: "unauthorized" },
+              query: { error: "session-expired" },
             },
-            "/admin/login?error=unauthorized"
+            "/admin/login?error=session-expired"
           );
         } else {
           console.error("인증 체크 중 오류 발생:", error);

--- a/components/auth/SessionTimer.jsx
+++ b/components/auth/SessionTimer.jsx
@@ -1,0 +1,35 @@
+import { useState, useEffect } from "react";
+
+export default function SessionTimer() {
+  const [remainingTime, setRemainingTime] = useState(0);
+
+  useEffect(() => {
+    const sessionStart = localStorage.getItem("sessionStart");
+
+    if (sessionStart) {
+      const sessionStartTime = new Date(sessionStart).getTime();
+      const sessionDuration = 60 * 60 * 1000; // 1시간 = 3600초 = 3600,000ms
+      const sessionEndTime = sessionStartTime + sessionDuration;
+
+      const updateRemainingTime = () => {
+        const now = Date.now();
+        const diff = Math.floor((sessionEndTime - now) / 1000);
+        setRemainingTime(diff > 0 ? diff : 0);
+      };
+
+      updateRemainingTime(); // mount되자마자 한번 실행
+      const interval = setInterval(updateRemainingTime, 1000);
+
+      return () => clearInterval(interval);
+    }
+  }, []);
+
+  const minutes = Math.floor(remainingTime / 60);
+  const seconds = remainingTime % 60;
+
+  return (
+    <div className="text-sm text-gray-500">
+      세션 남은 시간: {minutes}:{seconds < 10 ? `0${seconds}` : seconds}
+    </div>
+  );
+}

--- a/components/layout/AdminLayout.jsx
+++ b/components/layout/AdminLayout.jsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { signOut } from "firebase/auth";
 import { auth } from "@/lib/firebase";
 import InlineSpinner from "@/components/common/InlineSpinner";
+import SessionTimer from "@/components/auth/SessionTimer";
 
 export default function AdminLayout({ children }) {
   const router = useRouter();
@@ -63,8 +64,12 @@ export default function AdminLayout({ children }) {
           </nav>
         </div>
 
-        {/* 로그아웃 */}
-        <div className="p-6 border-t">
+        {/* 로그아웃 + 세션 타이머 */}
+        <div className="p-6 border-t flex flex-col gap-4">
+          <div className="text-xs text-gray-400 text-center">
+            <SessionTimer />
+          </div>
+
           <button
             onClick={handleLogout}
             disabled={isLoading}

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -1,4 +1,5 @@
 import { getAuth } from "firebase-admin/auth";
+import { destroyCookie } from "nookies";
 
 export async function verifyAdminToken(req) {
   try {
@@ -26,4 +27,10 @@ export async function verifyAdminToken(req) {
     console.error("[auth] verifyIdToken 실패:", error.code, error.message);
     return null; // 어떤 오류든 일단 null로 처리 (500 방지)
   }
+}
+
+export function clearAuthCookie(ctx = null) {
+  destroyCookie(ctx, "admin-auth-token", {
+    path: "/",
+  });
 }

--- a/lib/cookies.js
+++ b/lib/cookies.js
@@ -1,0 +1,7 @@
+import { destroyCookie } from "nookies";
+
+export function clearAuthCookie(ctx = null) {
+  destroyCookie(ctx, "admin-auth-token", {
+    path: "/",
+  });
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "loneleap-admin",
       "version": "0.1.0",
       "dependencies": {
+        "axios": "^1.9.0",
         "date-fns": "^4.1.0",
         "firebase": "^11.6.0",
         "firebase-admin": "^13.2.0",
@@ -2215,8 +2216,7 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/autoprefixer": {
       "version": "10.4.21",
@@ -2280,6 +2280,32 @@
       "license": "MPL-2.0",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.9.0.tgz",
+      "integrity": "sha512-re4CqKTJaURpzbLHtIi6XpDv20/CnpXOtjRY5/CU32L8gU8ek9UIivcfvSWvmKEngmVbrUtPpdDwWDWL7DNHvg==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/axios/node_modules/form-data": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.2.tgz",
+      "integrity": "sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/axobject-query": {
@@ -2438,7 +2464,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -2640,7 +2665,6 @@
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "delayed-stream": "~1.0.0"
       },
@@ -2838,7 +2862,6 @@
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -2887,7 +2910,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
@@ -3021,7 +3043,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -3031,7 +3052,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -3069,7 +3089,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -3082,7 +3101,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -3861,6 +3879,26 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
+      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/for-each": {
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
@@ -3951,7 +3989,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "devOptional": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -4051,7 +4088,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -4076,7 +4112,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.1",
@@ -4315,7 +4350,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -4406,7 +4440,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -4419,7 +4452,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.3"
@@ -4435,7 +4467,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -5440,7 +5471,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -5488,7 +5518,6 @@
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -5498,7 +5527,6 @@
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "mime-db": "1.52.0"
       },
@@ -6280,6 +6308,12 @@
       "engines": {
         "node": ">=12.0.0"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
     },
     "node_modules/punycode": {
       "version": "2.3.1",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "axios": "^1.9.0",
     "date-fns": "^4.1.0",
     "firebase": "^11.6.0",
     "firebase-admin": "^13.2.0",

--- a/pages/admin/login.js
+++ b/pages/admin/login.js
@@ -13,6 +13,8 @@ export default function AdminLoginPage() {
       setError("관리자 계정이 아닙니다.");
     } else if (queryError === "unauthenticated") {
       setError("관리자 계정 로그인이 필요합니다.");
+    } else if (queryError === "session-expired") {
+      setError("세션이 만료되었습니다. 다시 로그인해주세요.");
     } else {
       setError("");
     }

--- a/pages/api/admin/auth.js
+++ b/pages/api/admin/auth.js
@@ -1,0 +1,31 @@
+import { adminAuth } from "@/lib/firebaseAdmin";
+import { clearAuthCookie } from "@/lib/auth";
+
+export default async function checkAdminAuth(req, res) {
+  try {
+    const token = req.cookies["admin-auth-token"];
+
+    if (!token) {
+      throw new Error("No token");
+    }
+
+    const decoded = await adminAuth.verifyIdToken(token);
+
+    const adminEmails = process.env.ADMIN_EMAILS
+      ? process.env.ADMIN_EMAILS.split(",").map((email) =>
+          email.trim().toLowerCase()
+        )
+      : [];
+
+    if (!adminEmails.includes(decoded.email.toLowerCase())) {
+      throw new Error("Unauthorized admin");
+    }
+
+    return res.status(200).json({ admin: true, uid: decoded.uid });
+  } catch (error) {
+    console.error("[auth] 인증 실패:", error.message);
+
+    clearAuthCookie({ res });
+    return res.status(401).json({ error: "Unauthorized" });
+  }
+}

--- a/pages/api/admin/auth.js
+++ b/pages/api/admin/auth.js
@@ -1,9 +1,11 @@
 import { adminAuth } from "@/lib/firebaseAdmin";
-import { clearAuthCookie } from "@/lib/auth";
+import { clearAuthCookie } from "@/lib/cookies";
+import { parseCookies } from "nookies";
 
 export default async function checkAdminAuth(req, res) {
   try {
-    const token = req.cookies["admin-auth-token"];
+    const cookies = parseCookies({ req });
+    const token = cookies["admin-auth-token"];
 
     if (!token) {
       throw new Error("No token");

--- a/pages/api/admin/login.js
+++ b/pages/api/admin/login.js
@@ -22,6 +22,7 @@ export default async function createAdminSession(req, res) {
       secure: process.env.NODE_ENV === "production",
       sameSite: "strict",
       path: "/",
+      maxAge: 60 * 60, // 1시간(3600초) 후 세션 만료
     });
 
     return res.status(200).json({ message: "로그인에 성공했습니다." });

--- a/pages/api/admin/login.js
+++ b/pages/api/admin/login.js
@@ -17,7 +17,7 @@ export default async function createAdminSession(req, res) {
     const decoded = await adminAuth.verifyIdToken(token);
 
     // HttpOnly 쿠키 저장
-    setCookie({ res }, "token", token, {
+    setCookie({ res }, "admin-auth-token", token, {
       httpOnly: true,
       secure: process.env.NODE_ENV === "production",
       sameSite: "strict",


### PR DESCRIPTION
### 주요 변경 사항
- 서버 세션 쿠키 만료 설정 (`maxAge: 1시간`) 추가
- 세션 만료 감지 시 자동 로그아웃 및 로그인 페이지 리다이렉트 처리
- 로그인 성공 시 `sessionStart`를 localStorage에 기록하여 새로고침해도 세션 타이머 유지
- 사이드바 하단에 SessionTimer 컴포넌트 추가 (세션 남은 시간 표시)
- 인증 실패 시 쿼리 파라미터 기반 에러 메시지 구분
  - `unauthenticated`: 로그인 필요
  - `not-admin`: 관리자 권한 없음
  - `session-expired`: 세션 만료
- 로그인 페이지에서 상황별 에러 메시지 자연스럽게 출력

### 테스트 체크리스트
- 비로그인 상태에서 `/admin` 접근 시 로그인 페이지 리다이렉트
- 관리자 아닌 계정으로 로그인 시 관리자 권한 없음 메시지 표시
- 정상 로그인 시 `/admin` 접근 및 세션 타이머 정상 표시
- 세션 만료(1시간 경과 또는 쿠키 삭제) 시 세션 만료 메시지 출력
- 새로고침 후에도 세션 타이머 정상 유지

### 추가 내용
- 관리자가 오랜 시간 동안 비활동 시 자동 로그아웃 처리를 통해 보안성을 강화했습니다.
- SessionTimer는 기본 1시간 기준으로 설정되어 있으며, 추후 설정 변경이 필요한 경우 쉽게 수정 가능합니다.
- 인증 흐름의 견고성과 UX 완성도가 향상되었습니다.
