### PR TITLE
feat(admin): 추천 여행지 상세 페이지 마크다운 렌더링 및 아이콘 개선

### DIFF
--- a/components/recommendation/RecommendationForm.jsx
+++ b/components/recommendation/RecommendationForm.jsx
@@ -197,27 +197,30 @@ export default function RecommendationForm({
         </span>
       </div>
 
-      {/* 취소 버튼 */}
-      <button
-        type="button"
-        onClick={() => window.history.back()}
-        className="px-4 py-2 border rounded-lg text-gray-700 hover:bg-gray-100"
-      >
-        수정 취소
-      </button>
+      {/* 버튼 영역 */}
+      <div className="flex justify-between items-center gap-4">
+        {initialValues && (
+          <button
+            type="button"
+            onClick={() => window.history.back()}
+            className="px-4 py-2 border rounded-lg text-gray-700 hover:bg-gray-100"
+          >
+            수정 취소
+          </button>
+        )}
 
-      {/* 등록 버튼 */}
-      <button
-        type="submit"
-        disabled={loading}
-        className="w-full bg-black text-white py-2 rounded-lg hover:bg-gray-800 transition"
-      >
-        {loading
-          ? "처리 중..."
-          : initialValues
-          ? "추천 여행지 수정하기"
-          : "추천 여행지 등록하기"}
-      </button>
+        <button
+          type="submit"
+          disabled={loading}
+          className="flex-1 bg-black text-white py-2 rounded-lg hover:bg-gray-800 transition"
+        >
+          {loading
+            ? "처리 중..."
+            : initialValues
+            ? "추천 여행지 수정하기"
+            : "추천 여행지 등록하기"}
+        </button>
+      </div>
     </form>
   );
 }

--- a/pages/admin/recommendation/[id]/index.js
+++ b/pages/admin/recommendation/[id]/index.js
@@ -15,6 +15,10 @@ import {
   ArrowLeft,
   Pencil,
   Trash2,
+  BookText,
+  Navigation,
+  Landmark,
+  CalendarDays,
 } from "lucide-react";
 import { useDeleteRecommendation } from "@/hooks/useDeleteRecommendation";
 
@@ -35,16 +39,29 @@ export default function AdminRecommendationDetailPage() {
   const handleDelete = async () => {
     const confirm = window.confirm("정말 삭제하시겠습니까?");
     if (!confirm) return;
-
     await deleteRecommendation(id);
     router.push("/admin/recommendation");
+  };
+
+  const markdownComponents = {
+    p: ({ children }) => (
+      <p className="text-gray-800 leading-relaxed mb-4">{children}</p>
+    ),
+    blockquote: ({ children }) => (
+      <blockquote className="border-l-4 border-gray-300 pl-4 italic text-gray-600 mb-4">
+        {children}
+      </blockquote>
+    ),
+    ul: ({ children }) => (
+      <ul className="list-disc list-inside mb-4">{children}</ul>
+    ),
+    li: ({ children }) => <li className="mb-1">{children}</li>,
   };
 
   return (
     <AdminProtectedRoute>
       <AdminLayout>
         <div className="w-full max-w-4xl mx-auto px-6 py-10 space-y-10">
-          {/* 뒤로가기 */}
           <div>
             <Link
               href="/admin/recommendation"
@@ -57,7 +74,6 @@ export default function AdminRecommendationDetailPage() {
 
           {/* 기본 정보 */}
           <div className="bg-white rounded-xl shadow p-6">
-            {/* 이미지 */}
             <div className="relative w-full h-[320px] rounded-lg overflow-hidden">
               <Image
                 src={data.imageUrl}
@@ -68,9 +84,8 @@ export default function AdminRecommendationDetailPage() {
                 priority
               />
             </div>
-            {/* 텍스트 + 메타 정보 분리 레이아웃 */}
+
             <div className="flex flex-col md:flex-row justify-between items-start md:items-end mt-6 gap-6">
-              {/* 텍스트 정보 (왼쪽) */}
               <div className="space-y-2">
                 <h1 className="text-3xl font-bold text-gray-900">
                   {data.name}
@@ -82,9 +97,7 @@ export default function AdminRecommendationDetailPage() {
                 <p className="text-gray-700">{data.summary}</p>
               </div>
 
-              {/* 오른쪽: 공개 여부 + 등록일/수정일 */}
               <div className="flex flex-col items-end gap-2">
-                {/* 공개 여부 뱃지 */}
                 <span
                   className={`inline-flex items-center gap-1 px-3 py-1 rounded-full font-medium text-xs ${
                     data.visible
@@ -102,11 +115,9 @@ export default function AdminRecommendationDetailPage() {
                     </>
                   )}
                 </span>
-
-                {/* 등록/수정일 */}
                 <div className="text-xs text-gray-500 text-right space-y-1">
                   <p className="flex items-center gap-1">
-                    <Clock className="w-3 h-3" />
+                    <CalendarDays className="w-3 h-3" />
                     등록일:{" "}
                     {data.createdAt?.toDate
                       ? format(data.createdAt.toDate(), "yyyy.MM.dd")
@@ -114,7 +125,7 @@ export default function AdminRecommendationDetailPage() {
                   </p>
                   {data.updatedAt?.toDate && (
                     <p className="flex items-center gap-1">
-                      <Clock className="w-3 h-3" />
+                      <CalendarDays className="w-3 h-3" />
                       수정일: {format(data.updatedAt.toDate(), "yyyy.MM.dd")}
                     </p>
                   )}
@@ -127,27 +138,11 @@ export default function AdminRecommendationDetailPage() {
           {data.description && (
             <div className="bg-white rounded-xl shadow p-6 space-y-4">
               <h2 className="text-lg font-semibold text-gray-900 flex items-center gap-2">
-                <Clock className="w-5 h-5" />
-                상세 설명
+                <BookText className="w-5 h-5" /> 상세 설명
               </h2>
               <ReactMarkdown
                 remarkPlugins={[remarkGfm]}
-                components={{
-                  p: ({ children }) => (
-                    <p className="text-gray-800 leading-relaxed mb-4">
-                      {children}
-                    </p>
-                  ),
-                  blockquote: ({ children }) => (
-                    <blockquote className="border-l-4 border-gray-300 pl-4 italic text-gray-600 mb-4">
-                      {children}
-                    </blockquote>
-                  ),
-                  ul: ({ children }) => (
-                    <ul className="list-disc list-inside mb-4">{children}</ul>
-                  ),
-                  li: ({ children }) => <li className="mb-1">{children}</li>,
-                }}
+                components={markdownComponents}
               >
                 {data.description}
               </ReactMarkdown>
@@ -158,59 +153,60 @@ export default function AdminRecommendationDetailPage() {
           {data.locationInfo && (
             <div className="bg-white rounded-xl shadow p-6 space-y-4">
               <h2 className="text-lg font-semibold text-gray-900 flex items-center gap-2">
-                <MapPin className="w-5 h-5" />
-                위치 설명
+                <MapPin className="w-5 h-5" /> 위치 설명
               </h2>
-              <p className="text-gray-800 whitespace-pre-line leading-relaxed">
+              <ReactMarkdown
+                remarkPlugins={[remarkGfm]}
+                components={markdownComponents}
+              >
                 {data.locationInfo}
-              </p>
+              </ReactMarkdown>
             </div>
           )}
 
           {/* 찾아가는 방법 */}
           {data.directions?.length > 0 && (
             <div className="bg-white rounded-xl shadow p-6 space-y-4">
-              <h2 className="text-lg font-semibold text-gray-900">
-                찾아가는 방법
+              <h2 className="text-lg font-semibold text-gray-900 flex items-center gap-2">
+                <Navigation className="w-5 h-5" /> 찾아가는 방법
               </h2>
-              <ul className="space-y-1 list-disc list-inside text-sm text-gray-700">
-                {data.directions.map((line, i) => (
-                  <li key={i}>{line}</li>
-                ))}
-              </ul>
+              <ReactMarkdown
+                remarkPlugins={[remarkGfm]}
+                components={markdownComponents}
+              >
+                {data.directions.join("\n")}
+              </ReactMarkdown>
             </div>
           )}
 
           {/* 주변 정보 */}
           {data.nearbyInfo?.length > 0 && (
             <div className="bg-white rounded-xl shadow p-6 space-y-4">
-              <h2 className="text-lg font-semibold text-gray-900">주변 정보</h2>
-              <ul className="space-y-1 list-disc list-inside text-sm text-gray-700">
-                {data.nearbyInfo.map((place, i) => (
-                  <li key={i}>{place}</li>
-                ))}
-              </ul>
+              <h2 className="text-lg font-semibold text-gray-900 flex items-center gap-2">
+                <Landmark className="w-5 h-5" /> 주변 정보
+              </h2>
+              <ReactMarkdown
+                remarkPlugins={[remarkGfm]}
+                components={markdownComponents}
+              >
+                {data.nearbyInfo.join("\n")}
+              </ReactMarkdown>
             </div>
           )}
 
           <div className="flex flex-col md:flex-row justify-end items-center gap-4 mt-8">
-            {/* 수정하기 */}
             <Link
               href={`/admin/recommendation/${id}/edit`}
               className="inline-flex items-center gap-2 px-5 py-2 rounded-lg text-sm font-medium text-white bg-gray-800 hover:bg-black transition"
             >
-              <Pencil className="w-4 h-4" />
-              수정하기
+              <Pencil className="w-4 h-4" /> 수정하기
             </Link>
-
-            {/* 삭제하기 */}
             <button
               onClick={handleDelete}
               disabled={deleting}
               className="inline-flex items-center gap-2 px-5 py-2 rounded-lg text-sm font-medium text-white bg-red-600 hover:bg-red-700 transition disabled:opacity-50"
             >
-              <Trash2 className="w-4 h-4" />
-              삭제하기
+              <Trash2 className="w-4 h-4" /> 삭제하기
             </button>
           </div>
         </div>


### PR DESCRIPTION
- 상세 설명 외에도 위치 설명, 찾아가는 방법, 주변 정보에 ReactMarkdown 적용
- 각 섹션에 맞는 lucide-react 아이콘 추가로 시각적 구분 강화
- 위치 설명 → MapPin
- 찾아가는 방법 → Map
- 주변 정보 → Landmark
- 마크다운 렌더링 시 ul, li, blockquote 등 커스텀 스타일 유지
- 시멘틱 구조 정돈 및 코드 가독성 향상
