### PR TITLE
feat(admin): 신고 관리 시스템 구조 대응 리팩토링 (리뷰/채팅 + 인터뷰형 리뷰 지원)

### DIFF
--- a/components/reports/details/ReviewReportDetail.jsx
+++ b/components/reports/details/ReviewReportDetail.jsx
@@ -31,18 +31,22 @@ export default function ReviewReportDetail({ report, onSuccess }) {
 
   return (
     <div className="p-6 space-y-6">
-      <DetailSection title="리뷰 원문">
-        {review?.content || "삭제된 리뷰입니다."}
-      </DetailSection>
-
       <DetailSection title="신고 사유">{reason}</DetailSection>
 
       <DetailSection title="신고자">{reporterId || "-"}</DetailSection>
 
-      <DetailSection title="신고일자">
-        {reportedAt
-          ? format(new Date(reportedAt), "yyyy.MM.dd HH:mm")
-          : "날짜 없음"}
+      <DetailSection title="리뷰 원문">
+        {review?.interviewAnswers ? (
+          <div className="space-y-2">
+            {Object.entries(review.interviewAnswers).map(([key, value]) => (
+              <p key={key} className="text-sm text-gray-700 leading-snug">
+                <strong>Q{key}.</strong> {value}
+              </p>
+            ))}
+          </div>
+        ) : (
+          "삭제된 리뷰입니다."
+        )}
       </DetailSection>
 
       <div className="pt-4 border-t">

--- a/components/reports/tables/ReviewReportTable.jsx
+++ b/components/reports/tables/ReviewReportTable.jsx
@@ -47,8 +47,25 @@ export default function ReviewReportTable({ reports = [], onSelect }) {
                 }}
               >
                 <td className="px-4 py-2 whitespace-nowrap">
-                  <div className="max-w-[240px] truncate">
-                    {report.review?.content || "삭제된 리뷰"}
+                  <div className="space-y-1 max-w-[260px]">
+                    <p className="text-sm font-medium text-gray-800">
+                      {report.review?.destination || "여행지 없음"}
+                    </p>
+
+                    {report.review?.interviewAnswers ? (
+                      Object.entries(report.review.interviewAnswers).map(
+                        ([key, value]) => (
+                          <p
+                            key={key}
+                            className="text-xs text-gray-600 truncate"
+                          >
+                            <strong>Q{key}.</strong> {value}
+                          </p>
+                        )
+                      )
+                    ) : (
+                      <p className="text-sm text-gray-400">삭제된 리뷰</p>
+                    )}
                   </div>
                 </td>
                 <td className="px-4 py-2 whitespace-nowrap">

--- a/components/reports/tables/ReviewReportTable.jsx
+++ b/components/reports/tables/ReviewReportTable.jsx
@@ -48,15 +48,7 @@ export default function ReviewReportTable({ reports = [], onSelect }) {
               >
                 <td className="px-4 py-2 whitespace-nowrap">
                   <div className="max-w-[240px] truncate">
-                    {report.review?.interviewAnswers
-                      ? Object.entries(report.review.interviewAnswers).map(
-                          ([key, value]) => (
-                            <p key={key}>
-                              <strong>Q{key}.</strong> {value}
-                            </p>
-                          )
-                        )
-                      : "삭제된 리뷰"}
+                    {report.review?.title || "삭제된 리뷰"}
                   </div>
                 </td>
                 <td className="px-4 py-2 whitespace-nowrap">

--- a/components/reports/tables/ReviewReportTable.jsx
+++ b/components/reports/tables/ReviewReportTable.jsx
@@ -47,25 +47,16 @@ export default function ReviewReportTable({ reports = [], onSelect }) {
                 }}
               >
                 <td className="px-4 py-2 whitespace-nowrap">
-                  <div className="space-y-1 max-w-[260px]">
-                    <p className="text-sm font-medium text-gray-800">
-                      {report.review?.destination || "여행지 없음"}
-                    </p>
-
-                    {report.review?.interviewAnswers ? (
-                      Object.entries(report.review.interviewAnswers).map(
-                        ([key, value]) => (
-                          <p
-                            key={key}
-                            className="text-xs text-gray-600 truncate"
-                          >
-                            <strong>Q{key}.</strong> {value}
-                          </p>
+                  <div className="max-w-[240px] truncate">
+                    {report.review?.interviewAnswers
+                      ? Object.entries(report.review.interviewAnswers).map(
+                          ([key, value]) => (
+                            <p key={key}>
+                              <strong>Q{key}.</strong> {value}
+                            </p>
+                          )
                         )
-                      )
-                    ) : (
-                      <p className="text-sm text-gray-400">삭제된 리뷰</p>
-                    )}
+                      : "삭제된 리뷰"}
                   </div>
                 </td>
                 <td className="px-4 py-2 whitespace-nowrap">

--- a/pages/admin/index.js
+++ b/pages/admin/index.js
@@ -130,10 +130,10 @@ export async function getServerSideProps() {
     const { db } = await import("@/lib/firebaseAdmin");
     const { getAuth } = await import("firebase-admin/auth");
 
-    const [reviewSnap, chatSnap, userSnap] = await Promise.all([
+    const [reviewSnap, chatSnap, activeUserSnap] = await Promise.all([
       db.collection("review_reports").get(),
       db.collection("chatReports").get(),
-      db.collection("users").get(),
+      db.collection("users_private").where("status", "==", "active").get(),
     ]);
 
     // 최근 신고 5개씩 가져오기
@@ -205,7 +205,7 @@ export async function getServerSideProps() {
         stats: {
           reviewReports: reviewSnap.size,
           chatReports: chatSnap.size,
-          activeUsers: userSnap.size,
+          activeUsers: activeUserSnap.size,
         },
         recentReports,
       },

--- a/pages/api/chatReports/getChatReports.js
+++ b/pages/api/chatReports/getChatReports.js
@@ -82,7 +82,7 @@ export default async function getChatReports(req, res) {
     // 5단계: 사용자 ID → 이메일 조회
     const reporterIds = [...new Set(data.map((r) => r.reporterId))];
     const userSnaps = await Promise.all(
-      reporterIds.map((uid) => db.collection("users").doc(uid).get())
+      reporterIds.map((uid) => db.collection("users_private").doc(uid).get())
     );
     const userMap = {};
     userSnaps.forEach((snap) => {

--- a/pages/api/reviewReports/deleteReviewWithReports.js
+++ b/pages/api/reviewReports/deleteReviewWithReports.js
@@ -39,9 +39,11 @@ export default async function deleteReviewWithReports(req, res) {
         .json({ error: "삭제할 리뷰가 존재하지 않습니다." });
     }
 
-    const { authorId } = reviewDoc.data();
-    if (!authorId) {
-      return res.status(400).json({ error: "작성자 정보가 없습니다." });
+    const createdBy = reviewDoc.data()?.createdBy;
+    const authorUid = createdBy?.uid;
+
+    if (!authorUid) {
+      return res.status(400).json({ error: "작성자 UID가 없습니다." });
     }
 
     // 5. 트랜잭션: 리뷰 + 신고 삭제 + 작성자 신고카운트 감소
@@ -51,7 +53,7 @@ export default async function deleteReviewWithReports(req, res) {
         transaction.delete(doc.ref);
       });
 
-      const userRef = db.collection("users").doc(authorId);
+      const userRef = db.collection("users_private").doc(authorUid);
       transaction.update(userRef, {
         reportedCount: admin.firestore.FieldValue.increment(-1),
       });

--- a/pages/api/reviewReports/dismissReviewReports.js
+++ b/pages/api/reviewReports/dismissReviewReports.js
@@ -33,15 +33,17 @@ export default async function dismissReviewReports(req, res) {
       return res.status(404).json({ error: "리뷰 문서를 찾을 수 없습니다." });
     }
 
-    const { authorId } = reviewDoc.data();
-    if (!authorId) {
-      return res.status(400).json({ error: "리뷰 작성자 정보가 없습니다." });
+    const createdBy = reviewDoc.data().createdBy;
+    const authorUid = createdBy?.uid;
+
+    if (!authorUid) {
+      return res.status(400).json({ error: "리뷰 작성자 UID가 없습니다." });
     }
 
     // 트랜잭션으로 신고 문서 삭제 + 작성자 reportedCount 감소
     await db.runTransaction(async (transaction) => {
       transaction.delete(docRef);
-      const userRef = db.collection("users").doc(authorId);
+      const userRef = db.collection("users_private").doc(authorUid);
       transaction.update(userRef, {
         reportedCount: admin.firestore.FieldValue.increment(-1),
       });

--- a/pages/api/reviewReports/getReviewReports.js
+++ b/pages/api/reviewReports/getReviewReports.js
@@ -52,10 +52,7 @@ export default async function getReviewReportsHandler(req, res) {
     const reviewsMap = {};
     reviewSnaps.forEach((snap) => {
       if (snap.exists) {
-        console.log("✅ 리뷰 있음:", snap.id);
         reviewsMap[snap.id] = snap.data();
-      } else {
-        console.log("❌ 리뷰 없음:", snap.id);
       }
     });
 
@@ -65,6 +62,7 @@ export default async function getReviewReportsHandler(req, res) {
         ...report,
         review: review
           ? {
+              title: review.title || null,
               destination: review.destination || null,
               interviewAnswers: review.interviewAnswers || null,
               imageUrl: review.imageUrl || null,


### PR DESCRIPTION
### 주요 변경 사항

이번 PR에서는 관리자 페이지의 리뷰/채팅 신고 관리 기능 전반을 Firestore 컬렉션 구조 개편에 맞게 전면 수정하였습니다. 또한 인터뷰형 리뷰 데이터 구조에 맞춰 리뷰 출력 방식을 개선하고, 사용자 정보 조회 경로를 `users_private` 기준으로 통일하였습니다.

### 리뷰 신고 관련 개선 사항

- `getReviewReportsHandler` API에서 인터뷰형 리뷰 구조 반영 (title, destination, interviewAnswers 등 포함)
- 프론트 `ReviewReportTable`에서 리뷰 답변 목록 출력 → `title` 중심 출력으로 변경
- 리뷰 상세 뷰에서도 인터뷰형 리뷰 출력 구조 적용 (중복 제거 포함)
- 삭제된 리뷰 처리 시 fallback 문구 적용
- 신고 무시(`dismissReviewReports`) 및 삭제(`deleteReviewWithReports`) 시 `createdBy.uid` 기반 처리 + `users_private`에서 신고 카운트 감소

### 채팅 신고 관련 개선 사항

- `getChatReports` API에서 신고 메시지의 작성자 정보(`sender.displayName`, `photoURL`, `uid`) 함께 반환
- `users_private` 기준으로 reporter 이메일 조회
- 신고 무시(`dismissChatReport`) 및 삭제(`deleteMessageWithReports`) 시 `sender.uid` 기반 처리 및 신고 카운트 감소

### 기타 수정

- 관리자 대시보드에서 활성 사용자 수(`users_private`에서 status == "active") 정상 표시
