### PR TITLE
fix: reportedCount 음수 방지 로직 추가 (0 이하일 경우 업데이트 생략)

### DIFF
--- a/pages/api/chatReports/deleteMessageWithReports.js
+++ b/pages/api/chatReports/deleteMessageWithReports.js
@@ -66,9 +66,15 @@ export default async function deleteMessageWithReports(req, res) {
 
       // 3. 해당 유저의 reportedCount 감소
       const userRef = db.collection("users_private").doc(senderUid);
-      transaction.update(userRef, {
-        reportedCount: admin.firestore.FieldValue.increment(-1),
-      });
+      const userSnap = await transaction.get(userRef);
+      const currentCount = userSnap.data()?.reportedCount || 0;
+
+      // 0 이하로 내려가지 않도록 조건 처리
+      if (currentCount > 0) {
+        transaction.update(userRef, {
+          reportedCount: admin.firestore.FieldValue.increment(-1),
+        });
+      }
     });
 
     return res.status(200).json({ message: "메시지 및 관련 신고 삭제 완료" });

--- a/pages/api/chatReports/dismissChatReports.js
+++ b/pages/api/chatReports/dismissChatReports.js
@@ -55,9 +55,15 @@ export default async function dismissChatReport(req, res) {
 
       // 유저 신고 카운트 감소
       const userRef = db.collection("users_private").doc(senderUid);
-      transaction.update(userRef, {
-        reportedCount: admin.firestore.FieldValue.increment(-1),
-      });
+      const userSnap = await transaction.get(userRef);
+      const currentCount = userSnap.data()?.reportedCount || 0;
+
+      // 0 이하로 내려가지 않도록 방어
+      if (currentCount > 0) {
+        transaction.update(userRef, {
+          reportedCount: admin.firestore.FieldValue.increment(-1),
+        });
+      }
 
       // 감사 로그
       const adminId = decoded.uid || decoded.email || "unknown";

--- a/pages/api/reviewReports/deleteReviewWithReports.js
+++ b/pages/api/reviewReports/deleteReviewWithReports.js
@@ -54,9 +54,14 @@ export default async function deleteReviewWithReports(req, res) {
       });
 
       const userRef = db.collection("users_private").doc(authorUid);
-      transaction.update(userRef, {
-        reportedCount: admin.firestore.FieldValue.increment(-1),
-      });
+      const userSnap = await transaction.get(userRef);
+      const currentCount = userSnap.data()?.reportedCount || 0;
+
+      if (currentCount > 0) {
+        transaction.update(userRef, {
+          reportedCount: admin.firestore.FieldValue.increment(-1),
+        });
+      }
     });
 
     return res.status(200).json({


### PR DESCRIPTION
- Firestore 트랜잭션 내 사용자 문서 조회 후 현재 reportedCount 확인
- 0 이하로 내려가는 케이스 방어
- 클라이언트/서버 데이터 불일치 최소화 목적
