### PR TITLE
feat: 관리자 페이지 사용자 상태 제어 및 계정 삭제 시 전체 콘텐츠 동시 삭제 기능 구현

### DIFF
--- a/components/users/UserActionButtons.jsx
+++ b/components/users/UserActionButtons.jsx
@@ -25,7 +25,9 @@ export default function UserActionButtons({ userId, currentStatus }) {
     if (!confirm) return;
 
     try {
-      await recoverUser(userId);
+      await recoverUser(userId); // Firebase Auth 복구
+      await updateUserStatus(userId, "active"); // Firestore 상태 업데이트
+
       alert("계정이 복구되었습니다.");
     } catch (err) {
       console.error("계정 복구 실패:", err);

--- a/components/users/UserActionButtons.jsx
+++ b/components/users/UserActionButtons.jsx
@@ -1,7 +1,8 @@
-import { suspendUser, recoverUser, deleteUser } from "@/lib/admin";
+import { suspendUser, recoverUser } from "@/lib/admin";
 
 import { PauseCircle, Trash2, RotateCcw } from "lucide-react";
-import { updateUserStatus, deleteUserAccount } from "@/lib/users";
+import { updateUserStatus } from "@/lib/users";
+import { deleteUserRequest } from "@/lib/client/deleteUserRequest";
 
 export default function UserActionButtons({ userId, currentStatus }) {
   const handleSuspend = async () => {
@@ -36,20 +37,19 @@ export default function UserActionButtons({ userId, currentStatus }) {
   };
 
   const handleDelete = async () => {
-    const confirm = window.confirm(
-      "정말 이 계정을 완전히 삭제하시겠어요? 이 작업은 되돌릴 수 없습니다."
+    const confirmDelete = window.confirm(
+      "정말 이 계정을 완전히 삭제하시겠어요?\n이 작업은 되돌릴 수 없습니다."
     );
-    if (!confirm) return;
+    if (!confirmDelete) return;
 
     try {
-      await deleteUser(userId); // Firebase 인증 삭제
-      await deleteUserAccount(userId); // Firestore 문서 삭제
+      await deleteUserRequest(userId); // 인증 + DB + 콘텐츠 삭제
+      alert("계정이 성공적으로 삭제되었습니다.");
 
-      alert("계정이 삭제되었습니다.");
-      // TODO: UI에서 목록 새로고침 필요
+      if (typeof onSuccess === "function") onSuccess();
     } catch (err) {
       console.error("계정 삭제 실패:", err);
-      alert("오류가 발생했습니다.");
+      alert(err.message || "삭제 중 오류가 발생했습니다.");
     }
   };
 

--- a/components/users/UserActionButtons.jsx
+++ b/components/users/UserActionButtons.jsx
@@ -1,4 +1,4 @@
-import { suspendUser } from "@/lib/admin";
+import { suspendUser, recoverUser } from "@/lib/admin";
 
 import { PauseCircle, Trash2, RotateCcw } from "lucide-react";
 import { updateUserStatus, deleteUserAccount } from "@/lib/users";
@@ -23,8 +23,9 @@ export default function UserActionButtons({ userId, currentStatus }) {
   const handleRecover = async () => {
     const confirm = window.confirm("이 사용자의 계정을 다시 활성화할까요?");
     if (!confirm) return;
+
     try {
-      await updateUserStatus(userId, "active");
+      await recoverUser(userId);
       alert("계정이 복구되었습니다.");
     } catch (err) {
       console.error("계정 복구 실패:", err);

--- a/components/users/UserActionButtons.jsx
+++ b/components/users/UserActionButtons.jsx
@@ -1,4 +1,4 @@
-import { suspendUser, recoverUser } from "@/lib/admin";
+import { suspendUser, recoverUser, deleteUser } from "@/lib/admin";
 
 import { PauseCircle, Trash2, RotateCcw } from "lucide-react";
 import { updateUserStatus, deleteUserAccount } from "@/lib/users";
@@ -40,12 +40,16 @@ export default function UserActionButtons({ userId, currentStatus }) {
       "정말 이 계정을 완전히 삭제하시겠어요? 이 작업은 되돌릴 수 없습니다."
     );
     if (!confirm) return;
+
     try {
-      await deleteUserAccount(userId);
+      await deleteUser(userId); // Firebase 인증 삭제
+      await deleteUserAccount(userId); // Firestore 문서 삭제
+
       alert("계정이 삭제되었습니다.");
+      // TODO: UI에서 목록 새로고침 필요
     } catch (err) {
       console.error("계정 삭제 실패:", err);
-      alert("삭제 중 오류가 발생했습니다.");
+      alert("오류가 발생했습니다.");
     }
   };
 

--- a/components/users/UserActionButtons.jsx
+++ b/components/users/UserActionButtons.jsx
@@ -1,0 +1,35 @@
+import { PauseCircle, Trash2, RotateCcw } from "lucide-react";
+import { updateUserStatus } from "@/lib/users";
+
+export default function UserActionButtons({ userId }) {
+  const handleSuspend = async () => {
+    const confirm = window.confirm("정말 이 사용자의 계정을 정지하시겠어요?");
+    if (!confirm) return;
+
+    try {
+      await updateUserStatus(userId, "suspended");
+      alert("계정이 정지되었습니다.");
+      // 리프레시 필요 시 외부에서 처리
+    } catch (err) {
+      console.error("계정 정지 실패:", err);
+      alert("오류가 발생했습니다.");
+    }
+  };
+
+  return (
+    <div className="flex items-center justify-center space-x-2">
+      <button className="text-gray-400 hover:text-blue-500">
+        <RotateCcw size={16} strokeWidth={1.8} />
+      </button>
+      <button
+        onClick={handleSuspend}
+        className="text-gray-400 hover:text-yellow-500"
+      >
+        <PauseCircle size={16} strokeWidth={1.8} />
+      </button>
+      <button className="text-gray-400 hover:text-red-500">
+        <Trash2 size={16} strokeWidth={1.8} />
+      </button>
+    </div>
+  );
+}

--- a/components/users/UserActionButtons.jsx
+++ b/components/users/UserActionButtons.jsx
@@ -1,8 +1,7 @@
 import { PauseCircle, Trash2, RotateCcw } from "lucide-react";
-import { updateUserStatus } from "@/lib/users";
+import { updateUserStatus, deleteUserAccount } from "@/lib/users";
 
 export default function UserActionButtons({ userId, currentStatus }) {
-  console.log("currentStatus:", currentStatus);
   const handleSuspend = async () => {
     const confirm = window.confirm("정말 이 사용자의 계정을 정지하시겠어요?");
     if (!confirm) return;
@@ -29,6 +28,20 @@ export default function UserActionButtons({ userId, currentStatus }) {
     }
   };
 
+  const handleDelete = async () => {
+    const confirm = window.confirm(
+      "정말 이 계정을 완전히 삭제하시겠어요? 이 작업은 되돌릴 수 없습니다."
+    );
+    if (!confirm) return;
+    try {
+      await deleteUserAccount(userId);
+      alert("계정이 삭제되었습니다.");
+    } catch (err) {
+      console.error("계정 삭제 실패:", err);
+      alert("삭제 중 오류가 발생했습니다.");
+    }
+  };
+
   return (
     <div className="flex items-center justify-center space-x-2">
       <button
@@ -51,7 +64,11 @@ export default function UserActionButtons({ userId, currentStatus }) {
       >
         <PauseCircle size={16} strokeWidth={1.8} />
       </button>
-      <button className="text-gray-400 hover:text-red-500">
+      <button
+        onClick={handleDelete}
+        className="text-gray-400 hover:text-red-500"
+        title="계정 삭제"
+      >
         <Trash2 size={16} strokeWidth={1.8} />
       </button>
     </div>

--- a/components/users/UserActionButtons.jsx
+++ b/components/users/UserActionButtons.jsx
@@ -1,3 +1,5 @@
+import { suspendUser } from "@/lib/admin";
+
 import { PauseCircle, Trash2, RotateCcw } from "lucide-react";
 import { updateUserStatus, deleteUserAccount } from "@/lib/users";
 
@@ -7,9 +9,11 @@ export default function UserActionButtons({ userId, currentStatus }) {
     if (!confirm) return;
 
     try {
-      await updateUserStatus(userId, "suspended");
+      await suspendUser(userId); // Firebase Auth 정지
+      await updateUserStatus(userId, "suspended"); // Firestore 상태 반영
+
       alert("계정이 정지되었습니다.");
-      // 리프레시 필요 시 외부에서 처리
+      location.reload(); // 필요 시 상태 새로고침
     } catch (err) {
       console.error("계정 정지 실패:", err);
       alert("오류가 발생했습니다.");

--- a/components/users/UserActionButtons.jsx
+++ b/components/users/UserActionButtons.jsx
@@ -1,7 +1,8 @@
 import { PauseCircle, Trash2, RotateCcw } from "lucide-react";
 import { updateUserStatus } from "@/lib/users";
 
-export default function UserActionButtons({ userId }) {
+export default function UserActionButtons({ userId, currentStatus }) {
+  console.log("currentStatus:", currentStatus);
   const handleSuspend = async () => {
     const confirm = window.confirm("정말 이 사용자의 계정을 정지하시겠어요?");
     if (!confirm) return;
@@ -16,14 +17,37 @@ export default function UserActionButtons({ userId }) {
     }
   };
 
+  const handleRecover = async () => {
+    const confirm = window.confirm("이 사용자의 계정을 다시 활성화할까요?");
+    if (!confirm) return;
+    try {
+      await updateUserStatus(userId, "active");
+      alert("계정이 복구되었습니다.");
+    } catch (err) {
+      console.error("계정 복구 실패:", err);
+      alert("오류가 발생했습니다.");
+    }
+  };
+
   return (
     <div className="flex items-center justify-center space-x-2">
-      <button className="text-gray-400 hover:text-blue-500">
+      <button
+        onClick={handleRecover}
+        className={`text-gray-400 hover:text-blue-500 ${
+          currentStatus === "suspended" ? "" : "opacity-40 cursor-not-allowed"
+        }`}
+        disabled={currentStatus !== "suspended"}
+        title="계정 복구"
+      >
         <RotateCcw size={16} strokeWidth={1.8} />
       </button>
       <button
         onClick={handleSuspend}
-        className="text-gray-400 hover:text-yellow-500"
+        className={`text-gray-400 hover:text-yellow-500 ${
+          currentStatus === "suspended" ? "opacity-40 cursor-not-allowed" : ""
+        }`}
+        disabled={currentStatus === "suspended"}
+        title="계정 정지"
       >
         <PauseCircle size={16} strokeWidth={1.8} />
       </button>

--- a/components/users/UserTable.jsx
+++ b/components/users/UserTable.jsx
@@ -1,6 +1,6 @@
 import UserActionButtons from "@/components/users/UserActionButtons";
 
-export default function UserTable({ users }) {
+export default function UserTable({ users, onReload }) {
   const formatCreatedAt = (createdAt) => {
     if (!createdAt) return "N/A";
     const date =
@@ -112,6 +112,7 @@ export default function UserTable({ users }) {
                 <UserActionButtons
                   userId={user.id}
                   currentStatus={user.status}
+                  onSuccess={onReload}
                 />
               </td>
             </tr>

--- a/components/users/UserTable.jsx
+++ b/components/users/UserTable.jsx
@@ -109,7 +109,10 @@ export default function UserTable({ users }) {
 
               {/* 액션 버튼 */}
               <td className="px-4 py-4 text-center space-x-2">
-                <UserActionButtons userId={user.id} userStatus={user.status} />
+                <UserActionButtons
+                  userId={user.id}
+                  currentStatus={user.status}
+                />
               </td>
             </tr>
           ))}

--- a/components/users/UserTable.jsx
+++ b/components/users/UserTable.jsx
@@ -1,4 +1,4 @@
-import { Pencil, PauseCircle, Trash2 } from "lucide-react";
+import UserActionButtons from "@/components/users/UserActionButtons";
 
 export default function UserTable({ users }) {
   const formatCreatedAt = (createdAt) => {
@@ -109,15 +109,7 @@ export default function UserTable({ users }) {
 
               {/* 액션 버튼 */}
               <td className="px-4 py-4 text-center space-x-2">
-                <button className="text-gray-400 hover:text-blue-500">
-                  <Pencil size={16} strokeWidth={1.8} />
-                </button>
-                <button className="text-gray-400 hover:text-yellow-500">
-                  <PauseCircle size={16} strokeWidth={1.8} />
-                </button>
-                <button className="text-gray-400 hover:text-red-500">
-                  <Trash2 size={16} strokeWidth={1.8} />
-                </button>
+                <UserActionButtons userId={user.id} userStatus={user.status} />
               </td>
             </tr>
           ))}

--- a/components/users/UserTableContainer.jsx
+++ b/components/users/UserTableContainer.jsx
@@ -14,6 +14,7 @@ export default function UserTableContainer() {
   });
   const [search, setSearch] = useState("");
   const [currentPage, setCurrentPage] = useState(1);
+
   const usersPerPage = 10;
 
   useEffect(() => {
@@ -29,6 +30,15 @@ export default function UserTableContainer() {
     };
     load();
   }, []);
+
+  const loadUsers = async () => {
+    try {
+      const data = await fetchUsers();
+      setUsers(data);
+    } catch (error) {
+      console.error("사용자 로딩 실패:", error);
+    }
+  };
 
   // 필터 상태 변경
   const handleFilterChange = (key, value) => {
@@ -89,7 +99,7 @@ export default function UserTableContainer() {
         <p className="text-gray-500">검색 결과가 없습니다.</p>
       ) : (
         <>
-          <UserTable users={currentUsers} />
+          <UserTable users={currentUsers} onReload={loadUsers} />
 
           {/* 페이지네이션 */}
           <div className="flex justify-center gap-2 mt-6">

--- a/lib/admin.js
+++ b/lib/admin.js
@@ -24,3 +24,15 @@ export const recoverUser = async (uid) => {
   if (!res.ok) throw new Error(result.error || "복구 실패");
   return result;
 };
+
+export const deleteUser = async (uid) => {
+  const res = await fetch("/api/admin/deleteUser", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ uid }),
+  });
+
+  const result = await res.json();
+  if (!res.ok) throw new Error(result.error || "삭제 실패");
+  return result;
+};

--- a/lib/admin.js
+++ b/lib/admin.js
@@ -12,3 +12,15 @@ export const suspendUser = async (uid) => {
 
   return await res.json();
 };
+
+export const recoverUser = async (uid) => {
+  const res = await fetch("/api/admin/enableUser", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ uid }),
+  });
+
+  const result = await res.json();
+  if (!res.ok) throw new Error(result.error || "복구 실패");
+  return result;
+};

--- a/lib/admin.js
+++ b/lib/admin.js
@@ -1,0 +1,14 @@
+export const suspendUser = async (uid) => {
+  const res = await fetch("/api/admin/disableUser", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ uid }),
+  });
+
+  if (!res.ok) {
+    const data = await res.json();
+    throw new Error(data.error || "계정 정지 실패");
+  }
+
+  return await res.json();
+};

--- a/lib/client/deleteUserRequest.js
+++ b/lib/client/deleteUserRequest.js
@@ -1,0 +1,11 @@
+export const deleteUserRequest = async (uid) => {
+  const res = await fetch("/api/admin/deleteUser", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ uid }),
+  });
+
+  const data = await res.json();
+  if (!res.ok) throw new Error(data.error || "계정 삭제 실패");
+  return data;
+};

--- a/lib/server/deleteUserData.js
+++ b/lib/server/deleteUserData.js
@@ -1,0 +1,106 @@
+import { db, adminAuth } from "@/lib/firebaseAdmin";
+
+/**
+ * UID 기반으로 유저의 모든 컨텐츠 + 계정 삭제
+ */
+export default async function deleteUserData(req, res) {
+  if (req.method !== "POST") return res.status(405).end();
+
+  const { uid } = req.body;
+  if (!uid) return res.status(400).json({ error: "UID 누락" });
+
+  try {
+    // 1. users_private & users_public 삭제
+    await Promise.all([
+      db.collection("users_private").doc(uid).delete(),
+      db.collection("users_public").doc(uid).delete(),
+    ]);
+
+    // 2. 일정 삭제
+    const itinerarySnap = await db
+      .collection("itineraries")
+      .where("createdBy.uid", "==", uid)
+      .get();
+
+    const itineraryDeletes = itinerarySnap.docs.map((doc) =>
+      db.collection("itineraries").doc(doc.id).delete()
+    );
+
+    // 3. 리뷰 + 리뷰 내 서브컬렉션 삭제
+    const reviewSnap = await db
+      .collection("reviews")
+      .where("createdBy.uid", "==", uid)
+      .get();
+
+    const reviewDeletes = reviewSnap.docs.map(async (doc) => {
+      const reviewRef = db.collection("reviews").doc(doc.id);
+
+      // likes
+      const likesSnap = await reviewRef.collection("likes").get();
+      const likesDeletes = likesSnap.docs.map((d) => d.ref.delete());
+
+      // comments (작성자만 삭제)
+      const commentsSnap = await reviewRef
+        .collection("comments")
+        .where("author.uid", "==", uid)
+        .get();
+      const commentsDeletes = commentsSnap.docs.map((d) => d.ref.delete());
+
+      await Promise.all([...likesDeletes, ...commentsDeletes]);
+      return reviewRef.delete();
+    });
+
+    // 4. 채팅 메시지 삭제
+    const msgSnap = await db
+      .collection("chatMessages")
+      .where("sender.uid", "==", uid)
+      .get();
+    const messageDeletes = msgSnap.docs.map((doc) =>
+      db.collection("chatMessages").doc(doc.id).delete()
+    );
+
+    // 5. 채팅방 삭제 (본인이 만든 채팅방만)
+    const chatRoomSnap = await db
+      .collection("chatRooms")
+      .where("createdBy.uid", "==", uid)
+      .get();
+    const chatRoomDeletes = chatRoomSnap.docs.map((doc) =>
+      db.collection("chatRooms").doc(doc.id).delete()
+    );
+
+    // 6. 신고 기록 삭제
+    const reviewReportSnap = await db
+      .collection("review_reports")
+      .where("reporterId", "==", uid)
+      .get();
+    const reviewReportDeletes = reviewReportSnap.docs.map((doc) =>
+      db.collection("review_reports").doc(doc.id).delete()
+    );
+
+    const chatReportSnap = await db
+      .collection("chatReports")
+      .where("reporterId", "==", uid)
+      .get();
+    const chatReportDeletes = chatReportSnap.docs.map((doc) =>
+      db.collection("chatReports").doc(doc.id).delete()
+    );
+
+    // 7. Firebase Authentication 계정 삭제
+    await adminAuth.deleteUser(uid);
+
+    // 병렬 처리 실행
+    await Promise.all([
+      ...itineraryDeletes,
+      ...reviewDeletes,
+      ...messageDeletes,
+      ...chatRoomDeletes,
+      ...reviewReportDeletes,
+      ...chatReportDeletes,
+    ]);
+
+    return res.status(200).json({ message: "모든 데이터 및 계정 삭제 완료" });
+  } catch (error) {
+    console.error("계정 삭제 실패:", error);
+    return res.status(500).json({ error: error.message || "서버 오류" });
+  }
+}

--- a/lib/users.js
+++ b/lib/users.js
@@ -1,4 +1,4 @@
-import { collection, getDocs } from "firebase/firestore";
+import { collection, doc, getDocs } from "firebase/firestore";
 import { db } from "@/lib/firebase";
 
 /**

--- a/lib/users.js
+++ b/lib/users.js
@@ -1,4 +1,4 @@
-import { collection, doc, getDocs } from "firebase/firestore";
+import { collection, doc, getDocs, updateDoc } from "firebase/firestore";
 import { db } from "@/lib/firebase";
 
 /**

--- a/lib/users.js
+++ b/lib/users.js
@@ -1,4 +1,10 @@
-import { collection, doc, getDocs, updateDoc } from "firebase/firestore";
+import {
+  collection,
+  doc,
+  getDocs,
+  updateDoc,
+  deleteDoc,
+} from "firebase/firestore";
 import { db } from "@/lib/firebase";
 
 /**
@@ -40,4 +46,11 @@ export async function fetchUsers() {
 export const updateUserStatus = async (uid, status) => {
   const userRef = doc(db, "users_private", uid);
   await updateDoc(userRef, { status });
+};
+
+export const deleteUserAccount = async (uid) => {
+  const privateRef = doc(db, "users_private", uid);
+  const publicRef = doc(db, "users_public", uid);
+
+  await Promise.all([deleteDoc(privateRef), deleteDoc(publicRef)]);
 };

--- a/lib/users.js
+++ b/lib/users.js
@@ -35,3 +35,9 @@ export async function fetchUsers() {
     throw error;
   }
 }
+
+// 사용자 상태 업데이트 함수
+export const updateUserStatus = async (uid, status) => {
+  const userRef = doc(db, "users_private", uid);
+  await updateDoc(userRef, { status });
+};

--- a/pages/api/admin/deleteUser.js
+++ b/pages/api/admin/deleteUser.js
@@ -1,0 +1,16 @@
+import { adminAuth } from "@/lib/firebaseAdmin";
+
+export default async function handler(req, res) {
+  if (req.method !== "POST") return res.status(405).end();
+
+  const { uid } = req.body;
+  if (!uid) return res.status(400).json({ error: "UID 누락" });
+
+  try {
+    await adminAuth.deleteUser(uid);
+    return res.status(200).json({ message: "계정이 삭제되었습니다." });
+  } catch (error) {
+    console.error("계정 삭제 실패:", error);
+    return res.status(500).json({ error: "Firebase 인증 삭제 실패" });
+  }
+}

--- a/pages/api/admin/deleteUser.js
+++ b/pages/api/admin/deleteUser.js
@@ -1,16 +1,16 @@
-import { adminAuth } from "@/lib/firebaseAdmin";
+import deleteUserData from "@/lib/server/deleteUserData";
 
-export default async function handler(req, res) {
+export default async function deleteUserHandler(req, res) {
+  console.log("/api/admin/deleteUser 호출됨");
   if (req.method !== "POST") return res.status(405).end();
 
   const { uid } = req.body;
   if (!uid) return res.status(400).json({ error: "UID 누락" });
 
   try {
-    await adminAuth.deleteUser(uid);
-    return res.status(200).json({ message: "계정이 삭제되었습니다." });
+    await deleteUserData(req, res);
   } catch (error) {
-    console.error("계정 삭제 실패:", error);
-    return res.status(500).json({ error: "Firebase 인증 삭제 실패" });
+    console.error("유저 삭제 실패:", error);
+    return res.status(500).json({ error: "서버 오류" });
   }
 }

--- a/pages/api/admin/disableUser.js
+++ b/pages/api/admin/disableUser.js
@@ -1,0 +1,18 @@
+import { adminAuth } from "@/lib/firebaseAdmin";
+
+export default async function disablehandler(req, res) {
+  if (req.method !== "POST") return res.status(405).end();
+
+  const { uid } = req.body;
+  if (!uid) {
+    return res.status(400).json({ error: "UID 누락" });
+  }
+
+  try {
+    await adminAuth.updateUser(uid, { disabled: true });
+    return res.status(200).json({ message: "계정이 정지되었습니다." });
+  } catch (error) {
+    console.error("계정 정지 실패:", error);
+    return res.status(500).json({ error: "서버 오류" });
+  }
+}

--- a/pages/api/admin/enableUser.js
+++ b/pages/api/admin/enableUser.js
@@ -1,6 +1,6 @@
 import { adminAuth } from "@/lib/firebaseAdmin";
 
-export default async function handler(req, res) {
+export default async function enableUserHandler(req, res) {
   if (req.method !== "POST") return res.status(405).end();
 
   const { uid } = req.body;

--- a/pages/api/admin/enableUser.js
+++ b/pages/api/admin/enableUser.js
@@ -1,0 +1,18 @@
+import { adminAuth } from "@/lib/firebaseAdmin";
+
+export default async function handler(req, res) {
+  if (req.method !== "POST") return res.status(405).end();
+
+  const { uid } = req.body;
+  if (!uid) {
+    return res.status(400).json({ error: "UID 누락" });
+  }
+
+  try {
+    await adminAuth.updateUser(uid, { disabled: false });
+    return res.status(200).json({ message: "계정이 복구되었습니다." });
+  } catch (error) {
+    console.error("계정 복구 실패:", error);
+    return res.status(500).json({ error: "서버 오류" });
+  }
+}


### PR DESCRIPTION
### 주요 변경 사항
- UserActionButtons.jsx 컴포넌트 분리 및 리팩토링
- 사용자 계정 정지/복구 기능 구현 (Firestore 상태 + Firebase Auth disabled 상태 연동)
- 관리자 페이지에서 사용자 삭제 기능 구현
  - Firestore: users_private, users_public 문서 삭제
  - 연관 콘텐츠 삭제:
    - itineraries (여행 일정)
    - reviews 및 서브컬렉션 likes, comments(comments는 삭제 안되는 문제 발생)
    - chatMessages, chatRooms
    - review_reports, chatReports
 - Firebase Auth: admin.auth().deleteUser(uid) 호출 포함
- Firestore 상태 업데이트 함수 updateUserStatus 추가
- 복구 시 상태 연동 누락 문제 수정

#### 이후 작업 예정
- review.comments에서 author.uid → authorUid 필드로 구조 개선 (삭제 최적화)
- 사용자 목록 내보내기 기능 추가 예정
