### PR TITLE
fix: 관리자 인증 UX 개선 및 계정 삭제 로직 정리

### DIFF
--- a/components/auth/AdminLoginForm.jsx
+++ b/components/auth/AdminLoginForm.jsx
@@ -36,7 +36,6 @@ export default function AdminLoginForm({ errorMessage }) {
     if (errorType) {
       const messages = {
         "login-required": "로그인이 필요합니다.",
-        "session-expired": "세션이 만료되었습니다. 다시 로그인해 주세요.",
         unauthorized: "관리자 권한이 없습니다.",
       };
 

--- a/components/auth/AdminProtectedRoute.jsx
+++ b/components/auth/AdminProtectedRoute.jsx
@@ -12,28 +12,22 @@ export default function AdminProtectedRoute({ children }) {
     const checkAuth = async () => {
       try {
         await axios.get("/api/admin/auth");
-        // 정상 인증 → 로딩 해제
         setLoading(false);
       } catch (error) {
         const errorCode = error.response?.data?.error;
-
-        // 인증 실패 시 쿠키 제거
         clearAuthCookie();
 
-        let errorQuery = "session-expired"; // 기본값
         if (errorCode === "unauthenticated") {
-          errorQuery = "login-required";
-        } else if (errorCode === "unauthorized") {
-          errorQuery = "unauthorized";
-        }
-
-        router.replace(
-          {
+          router.replace({
             pathname: "/admin/login",
-            query: { error: errorQuery },
-          },
-          `/admin/login?error=${errorQuery}`
-        );
+            query: { error: "login-required" },
+          });
+        } else if (errorCode === "unauthorized") {
+          router.replace({
+            pathname: "/admin/login",
+            query: { error: "unauthorized" },
+          });
+        }
       }
     };
 

--- a/components/auth/SessionTimer.jsx
+++ b/components/auth/SessionTimer.jsx
@@ -4,24 +4,30 @@ export default function SessionTimer() {
   const [remainingTime, setRemainingTime] = useState(0);
 
   useEffect(() => {
-    const sessionStart = localStorage.getItem("sessionStart");
+    const SESSION_START_KEY = "sessionStart";
+    const sessionStart = localStorage.getItem(SESSION_START_KEY);
 
-    if (sessionStart) {
-      const sessionStartTime = new Date(sessionStart).getTime();
-      const sessionDuration = 60 * 60 * 1000; // 1시간 = 3600초 = 3600,000ms
-      const sessionEndTime = sessionStartTime + sessionDuration;
+    if (!sessionStart) return;
 
-      const updateRemainingTime = () => {
-        const now = Date.now();
-        const diff = Math.floor((sessionEndTime - now) / 1000);
-        setRemainingTime(diff > 0 ? diff : 0);
-      };
+    const sessionStartTime = new Date(sessionStart).getTime();
+    const sessionDuration = 60 * 60 * 1000; // 1시간
+    const sessionEndTime = sessionStartTime + sessionDuration;
 
-      updateRemainingTime(); // mount되자마자 한번 실행
-      const interval = setInterval(updateRemainingTime, 1000);
+    const interval = setInterval(() => {
+      const now = Date.now();
+      const diff = Math.floor((sessionEndTime - now) / 1000);
+      const clamped = Math.max(diff, 0);
+      setRemainingTime(clamped);
 
-      return () => clearInterval(interval);
-    }
+      if (clamped === 0) {
+        clearInterval(interval);
+        localStorage.removeItem(SESSION_START_KEY);
+        alert("세션이 만료되었습니다. 다시 로그인해 주세요.");
+        window.location.href = "/admin/login";
+      }
+    }, 1000);
+
+    return () => clearInterval(interval);
   }, []);
 
   const minutes = Math.floor(remainingTime / 60);

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -1,4 +1,0 @@
-export const adminEmails = [
-  "admin@gmail.com", // 실제 운영 관리자 계정
-  "owner@example.com", // 테스트용 계정
-];

--- a/lib/server/deleteUserData.js
+++ b/lib/server/deleteUserData.js
@@ -26,27 +26,15 @@ export default async function deleteUserData(req, res) {
       db.collection("itineraries").doc(doc.id).delete()
     );
 
-    // 3. 리뷰 + 리뷰 내 서브컬렉션 삭제
+    // 3. 리뷰 + 서브컬렉션 유지 (likes/comments는 삭제 안 함)
     const reviewSnap = await db
       .collection("reviews")
       .where("createdBy.uid", "==", uid)
       .get();
 
-    const reviewDeletes = reviewSnap.docs.map(async (doc) => {
-      const reviewRef = db.collection("reviews").doc(doc.id);
-
-      // likes
-      const likesSnap = await reviewRef.collection("likes").get();
-      const likesDeletes = likesSnap.docs.map((d) => d.ref.delete());
-
-      // comments (작성자만 삭제)
-      const commentsSnap = await reviewRef
-        .collection("comments")
-        .where("author.uid", "==", uid)
-        .get();
-      const commentsDeletes = commentsSnap.docs.map((d) => d.ref.delete());
-
-      await Promise.all([...likesDeletes, ...commentsDeletes]);
+    const reviewDeletes = reviewSnap.docs.map(async (docSnapshot) => {
+      const reviewId = docSnapshot.id;
+      const reviewRef = db.collection("reviews").doc(reviewId);
       return reviewRef.delete();
     });
 


### PR DESCRIPTION
### 주요 변경사항

1. 관리자 인증 UX 개선
- 기존에는 세션 만료 시 쿼리 파라미터(/admin/login?error=session-expired)로 안내 문구 전달
- UX 일관성 및 예외 처리 한계로 인해 → alert() 기반 실시간 안내 방식으로 전환
- 세션 만료 시 즉시 팝업 경고 + 로그인 페이지로 이동 처리

2. 사용자 계정 삭제 로직 정리
- 리뷰 삭제 시 likes/comments는 유지하도록 정책 변경
- 이유: 좋아요/댓글은 타인의 상호작용 기록이므로, 실무에서도 유지하는 경우가 많음
- 서브컬렉션 삭제 로직 제거 → 전체 삭제 속도 및 안정성 향상

3. 환경변수 정리
- 기존 constants.js에서 사용하던 adminEmails 상수 제거
- .env의 ADMIN_EMAILS 설정으로 일원화 완료
- 인증 로직은 process.env.ADMIN_EMAILS만 참조하도록 통일
