### PR TITLE
fix: Firestore 트랜잭션 에러 해결 (리뷰/채팅 신고 처리)

### DIFF
--- a/pages/api/admin/report/chat/deleteWithReports.js
+++ b/pages/api/admin/report/chat/deleteWithReports.js
@@ -56,18 +56,15 @@ export default async function deleteMessageWithReports(req, res) {
         throw new Error("메시지 작성자 정보가 없습니다.");
       }
 
-      // 1. 메시지 삭제
+      const userRef = db.collection("users_private").doc(senderUid);
+      const userSnap = await transaction.get(userRef); // get 먼저 수행
+      const currentCount = userSnap.data()?.reportedCount || 0;
+
       transaction.delete(messageRef);
 
-      // 2. 관련 신고 문서들 삭제
       snapshot.docs.forEach((doc) => {
         transaction.delete(doc.ref);
       });
-
-      // 3. 해당 유저의 reportedCount 감소
-      const userRef = db.collection("users_private").doc(senderUid);
-      const userSnap = await transaction.get(userRef);
-      const currentCount = userSnap.data()?.reportedCount || 0;
 
       // 0 이하로 내려가지 않도록 조건 처리
       if (currentCount > 0) {

--- a/pages/api/admin/report/chat/dismiss.js
+++ b/pages/api/admin/report/chat/dismiss.js
@@ -50,13 +50,12 @@ export default async function dismissChatReport(req, res) {
 
     // 트랜잭션 처리
     await db.runTransaction(async (transaction) => {
-      // 신고 문서 삭제
-      transaction.delete(reportRef);
-
-      // 유저 신고 카운트 감소
       const userRef = db.collection("users_private").doc(senderUid);
       const userSnap = await transaction.get(userRef);
       const currentCount = userSnap.data()?.reportedCount || 0;
+
+      // 신고 문서 삭제
+      transaction.delete(reportRef);
 
       // 0 이하로 내려가지 않도록 방어
       if (currentCount > 0) {

--- a/pages/api/admin/report/review/dismiss.js
+++ b/pages/api/admin/report/review/dismiss.js
@@ -42,11 +42,11 @@ export default async function dismissReviewReports(req, res) {
 
     // 트랜잭션으로 신고 문서 삭제 + 작성자 reportedCount 감소
     await db.runTransaction(async (transaction) => {
-      transaction.delete(docRef);
-
       const userRef = db.collection("users_private").doc(authorUid);
       const userSnap = await transaction.get(userRef);
       const currentCount = userSnap.data()?.reportedCount || 0;
+
+      transaction.delete(docRef);
 
       // 0 이하로 내려가지 않도록 방어
       if (currentCount > 0) {


### PR DESCRIPTION
- 리뷰 삭제 및 신고 무시 로직에서 Firestore 트랜잭션 규칙 위반 오류 수정
  (모든 read 연산을 write보다 먼저 실행되도록 순서 재조정)
- 채팅 메시지 삭제 및 신고 무시 로직도 동일한 방식으로 트랜잭션 구조 수정
- 사용자 reportedCount 감소 시 0 이하로 내려가지 않도록 방어 처리
- 트랜잭션 내 감사 로그 기록도 write 순서에 포함되도록 위치 조정

FirestoreError: "transactions require all reads to be executed before all writes" 에러 해결