### PR TITLE
Refactor: 관리자 페이지 전반 주석 및 시맨틱 구조 개선

### DIFF
--- a/components/auth/AdminLoginForm.jsx
+++ b/components/auth/AdminLoginForm.jsx
@@ -4,6 +4,13 @@ import { FiMail, FiLock } from "react-icons/fi";
 import ButtonSpinner from "@/components/common/loading/ButtonSpinner";
 import FormInput from "@/components/common/form/FormInput";
 
+/**
+ * AdminLoginForm
+ * - LoneLeap 관리자 페이지 로그인 폼
+ * - 이메일/비밀번호 로그인 + 구글 로그인 지원
+ * - 입력 오류 및 로딩 상태 처리 포함
+ */
+
 export default function AdminLoginForm({
   email,
   password,
@@ -24,14 +31,18 @@ export default function AdminLoginForm({
       onSubmit={onSubmit}
       className="w-full max-w-md bg-white p-8 rounded-2xl shadow-lg"
     >
-      <div className="flex flex-col items-center mb-6">
+      {/* 로그인 설명 영역 */}
+      <header className="flex flex-col items-center mb-6 text-center">
         <div className="text-3xl">🔐</div>
-        <h2 className="text-xl font-bold mt-2">관리자 로그인</h2>
+        <h1 className="text-xl font-bold mt-2">관리자 로그인</h1>
         <p className="text-sm text-gray-500 mt-1">
           리뷰와 오픈채팅, LoneLeap의 소중한 공간을 지켜주세요.
         </p>
-      </div>
-      <div className="space-y-4">
+      </header>
+
+      {/* 입력 필드 영역 */}
+      <fieldset className="space-y-4">
+        {/* 이메일 입력 */}
         <div className="relative">
           <FormInput
             id="email"
@@ -46,6 +57,7 @@ export default function AdminLoginForm({
           />
         </div>
 
+        {/* 비밀번호 입력 */}
         <div className="relative">
           <FormInput
             id="password"
@@ -60,6 +72,7 @@ export default function AdminLoginForm({
           />
         </div>
 
+        {/* 비밀번호 확인 입력 */}
         <div className="relative">
           <FormInput
             id="confirmPassword"
@@ -72,7 +85,10 @@ export default function AdminLoginForm({
             ariaDescribedBy={passwordMatchErrorId}
           />
         </div>
+      </fieldset>
 
+      {/* 로그인 버튼 */}
+      <div className="mt-6">
         <button
           type="submit"
           disabled={loadingEmail || loadingGoogle}
@@ -80,10 +96,14 @@ export default function AdminLoginForm({
         >
           {loadingEmail ? <ButtonSpinner /> : "로그인"}
         </button>
+      </div>
 
-        <div className="text-center text-sm text-gray-400">또는</div>
+      {/* 또는 구글 로그인 */}
+      <div className="text-center text-sm text-gray-400">또는</div>
 
+      <div className="mt-2">
         <button
+          type="button"
           onClick={onGoogleLogin}
           disabled={loadingEmail || loadingGoogle}
           className="w-full flex items-center justify-center gap-2 border py-2 rounded-md hover:bg-gray-50 text-sm"
@@ -95,7 +115,10 @@ export default function AdminLoginForm({
             "Google 계정으로 로그인"
           )}
         </button>
+      </div>
 
+      {/* 오류 메시지 */}
+      <div className="mt-4 space-y-2">
         {passwordMatchError && (
           <ErrorMessage message={passwordMatchError} align="center" />
         )}

--- a/components/auth/AdminLoginFormContainer.jsx
+++ b/components/auth/AdminLoginFormContainer.jsx
@@ -8,6 +8,13 @@ import {
 import { auth } from "@/lib/firebase/client";
 import AdminLoginForm from "@/components/auth/AdminLoginForm";
 
+/**
+ * AdminLoginFormContainer
+ * - LoneLeap 관리자 로그인 컨테이너 컴포넌트
+ * - 입력 상태 관리, 유효성 검사, Firebase 인증 로직 처리
+ * - AdminLoginForm 컴포넌트에 props로 전달
+ */
+
 export default function AdminLoginFormContainer({ errorMessage }) {
   const router = useRouter();
 
@@ -22,6 +29,7 @@ export default function AdminLoginFormContainer({ errorMessage }) {
   const [loadingEmail, setLoadingEmail] = useState(false);
   const [loadingGoogle, setLoadingGoogle] = useState(false);
 
+  // 접근성용 오류 ID
   const emailErrorId = error?.includes("이메일") ? "email-error" : undefined;
   const passwordErrorId = error?.includes("비밀번호")
     ? "password-error"
@@ -30,6 +38,7 @@ export default function AdminLoginFormContainer({ errorMessage }) {
     ? "confirm-password-error"
     : undefined;
 
+  // URL 쿼리 기반 에러 메시지 처리
   useEffect(() => {
     if (errorMessage) {
       setError(errorMessage);
@@ -48,16 +57,18 @@ export default function AdminLoginFormContainer({ errorMessage }) {
     }
   }, [errorMessage, router.query.error]);
 
+  // 입력 값 변경 핸들러
   const handleChange = useCallback((key, value) => {
     setForm((prev) => ({ ...prev, [key]: value }));
   }, []);
 
+  // 이메일 로그인 처리
   const handleEmailLogin = async (e) => {
     e.preventDefault();
 
     const { email, password, confirmPassword } = form;
 
-    // 기본 유효성 검사
+    // 유효성 검사
     if (!email.trim()) return setError("이메일을 입력해주세요.");
     if (!password) return setError("비밀번호를 입력해주세요.");
     if (password !== confirmPassword) {
@@ -70,6 +81,7 @@ export default function AdminLoginFormContainer({ errorMessage }) {
     setPasswordMatchError("");
 
     try {
+      // Firebase 인증 → 토큰 발급 → 서버에 로그인 요청
       const userCredential = await signInWithEmailAndPassword(
         auth,
         email,
@@ -112,6 +124,7 @@ export default function AdminLoginFormContainer({ errorMessage }) {
     }
   };
 
+  // 구글 로그인 처리
   const handleGoogleLogin = async () => {
     setLoadingGoogle(true);
     setError("");

--- a/components/auth/AdminProtectedRoute.jsx
+++ b/components/auth/AdminProtectedRoute.jsx
@@ -4,6 +4,13 @@ import { clearAuthCookie } from "@/lib/server/cookies";
 import axios from "axios";
 import LoadingSpinner from "@/components/common/loading/LoadingSpinner";
 
+/**
+ * AdminProtectedRoute
+ * - LoneLeap 관리자 전용 페이지 보호 컴포넌트
+ * - Firebase 인증 토큰 검증 → 서버에서 관리자 권한 확인
+ * - 미인증 or 권한 없음 상태 시 로그인 페이지로 리다이렉트
+ */
+
 export default function AdminProtectedRoute({ children }) {
   const router = useRouter();
   const [loading, setLoading] = useState(true);
@@ -12,12 +19,18 @@ export default function AdminProtectedRoute({ children }) {
   useEffect(() => {
     const checkAuth = async () => {
       try {
+        // 서버에 인증 상태 요청 (Firebase ID 토큰 검사)
         await axios.get("/api/admin/auth/check");
+
+        // 인증 통과 → 관리자 권한 있음
         setAuthorized(true);
       } catch (error) {
         const errorCode = error.response?.data?.error;
+
+        // 인증 쿠키 제거
         clearAuthCookie();
 
+        // 인증 실패 시 로그인 페이지로 리다이렉트
         if (
           errorCode === "unauthenticated" &&
           router.pathname !== "/admin/login"
@@ -45,12 +58,13 @@ export default function AdminProtectedRoute({ children }) {
 
   return (
     <>
-      {/* title이 정의된 페이지에서는 여기까지 항상 렌더됨 */}
+      {/* 인증 확인 중에는 전체 화면 스피너 표시 */}
       {loading ? (
         <div className="flex justify-center items-center h-screen">
           <LoadingSpinner text="관리자 인증 중..." />
         </div>
       ) : authorized ? (
+        // 인증 완료 → 자식 컴포넌트 렌더링
         children
       ) : null}
     </>

--- a/components/auth/SessionTimer.jsx
+++ b/components/auth/SessionTimer.jsx
@@ -1,5 +1,12 @@
 import { useState, useEffect } from "react";
 
+/**
+ * SessionTimer
+ * - 관리자 세션 남은 시간을 실시간으로 표시하는 컴포넌트
+ * - 세션은 로그인 시점 기준으로 1시간 유지
+ * - 시간이 만료되면 localStorage 초기화 및 로그인 페이지로 강제 이동
+ */
+
 export default function SessionTimer() {
   const [remainingTime, setRemainingTime] = useState(0);
 
@@ -7,7 +14,7 @@ export default function SessionTimer() {
     const SESSION_START_KEY = "sessionStart";
     const sessionStart = localStorage.getItem(SESSION_START_KEY);
 
-    if (!sessionStart) return;
+    if (!sessionStart) return; // 세션 시작 정보 없음 → 타이머 동작 X
 
     const sessionStartTime = new Date(sessionStart).getTime();
     const sessionDuration = 60 * 60 * 1000; // 1시간
@@ -16,18 +23,19 @@ export default function SessionTimer() {
     const interval = setInterval(() => {
       const now = Date.now();
       const diff = Math.floor((sessionEndTime - now) / 1000);
-      const clamped = Math.max(diff, 0);
+      const clamped = Math.max(diff, 0); // 음수 방지
       setRemainingTime(clamped);
 
+      // 세션 만료 시 처리
       if (clamped === 0) {
         clearInterval(interval);
         localStorage.removeItem(SESSION_START_KEY);
         alert("세션이 만료되었습니다. 다시 로그인해 주세요.");
         window.location.href = "/admin/login";
       }
-    }, 1000);
+    }, 1000); // 1초마다 체크
 
-    return () => clearInterval(interval);
+    return () => clearInterval(interval); // 컴포넌트 언마운트 시 정리
   }, []);
 
   const minutes = Math.floor(remainingTime / 60);

--- a/components/dashboard/AdminDashboard.jsx
+++ b/components/dashboard/AdminDashboard.jsx
@@ -7,59 +7,86 @@ import ContentActivityBarChart from "@/components/dashboard/ContentActivityBarCh
 import EmptyState from "@/components/common/feedback/EmptyState";
 import { Inbox } from "lucide-react";
 
+/**
+ * AdminDashboard
+ * - 관리자 전용 대시보드 화면
+ * - 신고 통계, 사용자 활동 차트, 최근 신고 내역 테이블 등 제공
+ */
+
 export default function AdminDashboard({ stats, chartData, recentReports }) {
+  // 서버로부터 받아온 기본 통계값
   const reviewReports = stats?.reviewReports ?? 0;
   const chatReports = stats?.chatReports ?? 0;
   const activeUsers = stats?.activeUsers ?? 0;
 
+  // 공통 스타일 상수
   const cardStatBox = "bg-white p-4 rounded-xl shadow text-center";
   const tableCell = "py-2";
 
   return (
-    <div className="p-6 max-w-screen-xl mx-auto">
-      <h1 className="text-2xl font-bold mb-2">안녕하세요, 관리자님</h1>
-      <p className="text-gray-500 mb-6">
-        {new Date().toLocaleDateString("ko-KR", {
-          year: "numeric",
-          month: "long",
-          day: "numeric",
-          weekday: "long",
-        })}
-      </p>
+    <main className="p-6 max-w-screen-xl mx-auto">
+      {/* 관리자 인사 + 날짜 */}
+      <header className="mb-6">
+        <h1 className="text-2xl font-bold mb-2">안녕하세요, 관리자님</h1>
+        <p className="text-gray-500">
+          {new Date().toLocaleDateString("ko-KR", {
+            year: "numeric",
+            month: "long",
+            day: "numeric",
+            weekday: "long",
+          })}
+        </p>
+      </header>
 
-      {/* 통계 카드 */}
-      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 mb-6">
-        <div className={cardStatBox}>
-          신고된 리뷰: <strong>{reviewReports}</strong>
+      {/* 통계 카드 영역 */}
+      <section aria-labelledby="admin-stats" className="mb-6">
+        <h2 id="admin-stats" className="sr-only">
+          관리자 통계 카드
+        </h2>
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+          <div className={cardStatBox}>
+            신고된 리뷰: <strong>{reviewReports}</strong>
+          </div>
+          <div className={cardStatBox}>
+            신고된 채팅: <strong>{chatReports}</strong>
+          </div>
+          <div className={cardStatBox}>
+            활성 사용자: <strong>{activeUsers.toLocaleString()}명</strong>
+          </div>
         </div>
-        <div className={cardStatBox}>
-          신고된 채팅: <strong>{chatReports}</strong>
+      </section>
+
+      {/* 차트 시각화 영역 */}
+      <section aria-labelledby="admin-charts" className="mb-6">
+        <h2 id="admin-charts" className="sr-only">
+          신고 및 사용자 차트
+        </h2>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <ReviewReportLineChart data={chartData.reviewReports} />
+          <ChatReportLineChart data={chartData.chatReports} />
         </div>
-        <div className={cardStatBox}>
-          활성 사용자: <strong>{activeUsers.toLocaleString()}명</strong>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mt-4">
+          <UserStatusDoughnutChart data={chartData.userStatusDist} />
+          <ContentActivityBarChart data={chartData.activityByMonth} />
         </div>
-      </div>
+      </section>
 
-      {/* 차트 영역 */}
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-6">
-        <ReviewReportLineChart data={chartData.reviewReports} />
-        <ChatReportLineChart data={chartData.chatReports} />
-      </div>
-
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-6">
-        <UserStatusDoughnutChart data={chartData.userStatusDist} />
-        <ContentActivityBarChart data={chartData.activityByMonth} />
-      </div>
-
-      {/* 최근 신고 내역 */}
-      <div className="bg-white p-6 rounded-xl shadow overflow-x-auto">
+      {/* 최근 신고 테이블 */}
+      <section
+        aria-labelledby="recent-reports"
+        className="bg-white p-6 rounded-xl shadow overflow-x-auto"
+      >
         <div className="flex justify-between mb-4">
-          <h2 className="text-lg font-semibold">최근 신고 내역</h2>
+          <h2 id="recent-reports" className="text-lg font-semibold">
+            최근 신고 내역
+          </h2>
           <Link href="/admin/reports/reviews" className="text-sm text-blue-500">
             전체보기 →
           </Link>
         </div>
+
         <table className="min-w-[600px] w-full text-sm text-left">
+          <caption className="sr-only">최근 접수된 신고 리스트</caption>
           <thead>
             <tr className="text-gray-500 border-b">
               <th className={tableCell}>유형</th>
@@ -102,7 +129,7 @@ export default function AdminDashboard({ stats, chartData, recentReports }) {
             )}
           </tbody>
         </table>
-      </div>
-    </div>
+      </section>
+    </main>
   );
 }

--- a/components/dashboard/AdminDashboardContainer.jsx
+++ b/components/dashboard/AdminDashboardContainer.jsx
@@ -2,12 +2,19 @@ import AdminDashboard from "@/components/dashboard/AdminDashboard";
 import EmptyState from "@/components/common/feedback/EmptyState";
 import { AlertTriangle } from "lucide-react";
 
+/**
+ * AdminDashboardContainer
+ * - 관리자 대시보드의 SSR 데이터를 받아 UI 컴포넌트에 전달
+ * - 에러 발생 시 EmptyState 렌더링
+ */
+
 export default function AdminDashboardContainer({
   stats,
   chartData,
   recentReports,
   error,
 }) {
+  // 데이터 로딩 에러 시
   if (error) {
     return (
       <EmptyState

--- a/components/dashboard/ChatReportLineChart.jsx
+++ b/components/dashboard/ChatReportLineChart.jsx
@@ -18,25 +18,35 @@ import {
   chartHeading,
 } from "@/styles/chartStyles";
 
+/**
+ * ChatReportLineChart
+ * - 최근 7일간의 채팅 신고 건수를 선 그래프로 시각화
+ * - 데이터가 없을 경우 EmptyState 반환
+ * - Recharts 사용, 반응형 차트 컨테이너로 구성
+ * - 시맨틱 태그 + 접근성 처리(id/aria-labelledby)
+ */
+
 const chartMargin = { top: 10, right: 20, bottom: 0, left: 10 };
 const dotStyle = { r: 3 };
 
 function ChatReportLineChart({ data }) {
+  // 유효한 데이터가 있는지 확인
   const hasData = useMemo(() => Array.isArray(data) && data.length > 0, [data]);
 
+  // 데이터 없음 → EmptyState
   if (!hasData) {
     return (
-      <div className={chartEmptyBox}>
+      <section className={chartEmptyBox}>
         <EmptyState
           message="최근 채팅 신고 데이터가 없습니다."
           icon={<MessageSquareOff className="w-6 h-6 text-gray-300 mb-2" />}
         />
-      </div>
+      </section>
     );
   }
 
   return (
-    <div
+    <section
       className={chartContainerBox}
       role="region"
       aria-labelledby="chat-report-chart"
@@ -61,7 +71,7 @@ function ChatReportLineChart({ data }) {
           </LineChart>
         </ResponsiveContainer>
       </div>
-    </div>
+    </section>
   );
 }
 

--- a/components/dashboard/ContentActivityBarChart.jsx
+++ b/components/dashboard/ContentActivityBarChart.jsx
@@ -19,11 +19,20 @@ import {
   chartHeading,
 } from "@/styles/chartStyles";
 
+/**
+ * ContentActivityBarChart
+ * - 최근 6개월간 사용자 작성 활동(리뷰/일정 수)을 시각화
+ * - BarChart 구성, 월 기준으로 포맷된 데이터 사용
+ * - 데이터가 없을 경우 EmptyState 렌더링
+ */
+
 const chartMargin = { top: 10, right: 20, bottom: 0, left: 0 };
 
 function ContentActivityBarChart({ data }) {
+  // 데이터 유효성 확인
   const hasData = useMemo(() => Array.isArray(data) && data.length > 0, [data]);
 
+  // 월 포맷 정리 ("2025-05" → "05월")
   const formattedData = useMemo(
     () =>
       data?.map((item) => ({
@@ -33,19 +42,20 @@ function ContentActivityBarChart({ data }) {
     [data]
   );
 
+  // 데이터 없을 경우
   if (!hasData) {
     return (
-      <div className={chartEmptyBox}>
+      <section className={chartEmptyBox}>
         <EmptyState
           message="최근 작성 활동 데이터가 없습니다."
           icon={<BarChart3 className="w-6 h-6 text-gray-300 mb-2" />}
         />
-      </div>
+      </section>
     );
   }
 
   return (
-    <div
+    <section
       className={chartContainerBox}
       role="region"
       aria-labelledby="activity-bar-chart"
@@ -76,7 +86,7 @@ function ContentActivityBarChart({ data }) {
           </BarChart>
         </ResponsiveContainer>
       </div>
-    </div>
+    </section>
   );
 }
 

--- a/components/dashboard/ReviewReportLineChart.jsx
+++ b/components/dashboard/ReviewReportLineChart.jsx
@@ -17,6 +17,13 @@ import {
   chartHeading,
 } from "@/styles/chartStyles";
 
+/**
+ * ReviewReportLineChart
+ * - 최근 7일 리뷰 신고 수 데이터를 선 그래프로 시각화
+ * - 신고 수의 일별 추이를 확인할 수 있음
+ * - 데이터가 없을 경우 EmptyState 표시
+ */
+
 const chartMargin = { top: 10, right: 20, bottom: 0, left: 10 };
 const dotStyle = { r: 3 };
 
@@ -25,17 +32,17 @@ function ReviewReportLineChart({ data }) {
 
   if (!hasData) {
     return (
-      <div className={chartEmptyBox}>
+      <section className={chartEmptyBox}>
         <EmptyState
           message="최근 리뷰 신고 데이터가 없습니다."
           icon={<LineChart className="w-6 h-6 text-gray-300 mb-2" />}
         />
-      </div>
+      </section>
     );
   }
 
   return (
-    <div
+    <section
       className={chartContainerBox}
       role="region"
       aria-labelledby="review-report-chart"
@@ -60,7 +67,7 @@ function ReviewReportLineChart({ data }) {
           </LineChart>
         </ResponsiveContainer>
       </div>
-    </div>
+    </section>
   );
 }
 

--- a/components/dashboard/UserStatusDoughnutChart.jsx
+++ b/components/dashboard/UserStatusDoughnutChart.jsx
@@ -16,6 +16,12 @@ import {
   chartHeading,
 } from "@/styles/chartStyles";
 
+/**
+ * UserStatusDonutChart
+ * - 사용자 상태(예: 활성, 정지 등) 분포를 도넛 차트로 시각화
+ * - 데이터가 없을 경우 EmptyState 컴포넌트로 대체
+ */
+
 const COLORS = ["#10B981", "#F59E0B", "#9CA3AF"]; // 초록 / 주황 / 회색
 
 function UserStatusDonutChart({ data }) {
@@ -23,17 +29,17 @@ function UserStatusDonutChart({ data }) {
 
   if (!hasData) {
     return (
-      <div className={chartEmptyBox}>
+      <section className={chartEmptyBox}>
         <EmptyState
           message="사용자 상태 데이터가 없습니다."
           icon={<PieChart className="w-6 h-6 text-gray-300 mb-2" />}
         />
-      </div>
+      </section>
     );
   }
 
   return (
-    <div
+    <section
       className={chartContainerBox}
       role="region"
       aria-labelledby="user-status-chart"
@@ -67,7 +73,7 @@ function UserStatusDonutChart({ data }) {
           </PieChart>
         </ResponsiveContainer>
       </div>
-    </div>
+    </section>
   );
 }
 

--- a/components/layout/AdminLayout.jsx
+++ b/components/layout/AdminLayout.jsx
@@ -19,12 +19,19 @@ import { cn } from "@/lib/shared/utils";
 import { signOut } from "firebase/auth";
 import { auth } from "@/lib/firebase/client";
 
+/**
+ * AdminLayout
+ * - 관리자 페이지 전체 레이아웃 구성
+ * - 사이드바 열림 상태 로컬 스토리지 저장
+ * - 로그아웃 및 세션 타이머 포함
+ */
+
 export default function AdminLayout({ children }) {
   const [isSidebarOpen, setIsSidebarOpen] = useState(true);
   const [isLoading, setIsLoading] = useState(false);
   const router = useRouter();
 
-  // 사이드바 상태 유지
+  // 사이드바 상태 불러오기
   useEffect(() => {
     const saved = localStorage.getItem("sidebar-open");
     if (saved !== null) {
@@ -32,6 +39,7 @@ export default function AdminLayout({ children }) {
     }
   }, []);
 
+  // 사이드바 상태 저장
   useEffect(() => {
     localStorage.setItem("sidebar-open", isSidebarOpen.toString());
   }, [isSidebarOpen]);
@@ -43,8 +51,8 @@ export default function AdminLayout({ children }) {
       try {
         setIsLoading(true);
 
-        await signOut(auth); // Firebase 클라이언트 로그아웃
-        await fetch("/api/admin/auth/logout", { method: "POST" }); // 서버 쿠키 제거
+        await signOut(auth); // Firebase 로그아웃
+        await fetch("/api/admin/auth/logout", { method: "POST" }); // 서버 쿠키 삭제
 
         router.push("/admin/login");
       } catch (error) {
@@ -71,9 +79,10 @@ export default function AdminLayout({ children }) {
           "flex-shrink-0 bg-white border-r shadow-sm flex flex-col transition-all duration-300",
           isSidebarOpen ? "w-64" : "w-16"
         )}
+        aria-label="관리자 메뉴"
       >
-        {/* 상단 로고 & 토글 */}
-        <div className="flex items-center justify-between h-[60px] px-4 border-b">
+        {/* 로고 + 토글 버튼 */}
+        <header className="flex items-center justify-between h-[60px] px-4 border-b">
           <div className="flex items-center gap-2">
             <Footprints size={22} className="text-black" />
             {isSidebarOpen && (
@@ -82,11 +91,10 @@ export default function AdminLayout({ children }) {
               </span>
             )}
           </div>
-
           <button
             onClick={() => setIsSidebarOpen(!isSidebarOpen)}
             className="text-gray-500 hover:text-black"
-            aria-label="사이드바 토글"
+            aria-label="사이드바 열기/닫기"
           >
             {isSidebarOpen ? (
               <ChevronLeft size={20} />
@@ -94,10 +102,9 @@ export default function AdminLayout({ children }) {
               <ChevronRight size={20} />
             )}
           </button>
-        </div>
+        </header>
 
-        {/* 메뉴 */}
-
+        {/* 네비게이션 메뉴 */}
         <nav className="flex-1 flex flex-col gap-2 px-3 py-4 text-sm text-gray-700">
           {sidebarItems.map(({ href, label, icon }) => (
             <SidebarMenuItem
@@ -111,16 +118,13 @@ export default function AdminLayout({ children }) {
           ))}
         </nav>
 
-        {/* 하단 세션 + 로그아웃 */}
-        <div className="p-4 border-t flex flex-col gap-4 items-center">
-          {/* 세션 타이머: 열림 상태에서만 표시 */}
+        {/* 로그아웃 및 세션 타이머 */}
+        <footer className="p-4 border-t flex flex-col gap-4 items-center">
           {isSidebarOpen && (
             <div className="text-xs text-gray-400 text-center">
               <SessionTimer />
             </div>
           )}
-
-          {/* 로그아웃 버튼 */}
           <button
             onClick={handleLogout}
             disabled={isLoading}
@@ -133,12 +137,14 @@ export default function AdminLayout({ children }) {
             <LogOut size={20} />
             {isSidebarOpen && (isLoading ? <ButtonSpinner /> : "로그아웃")}
           </button>
-        </div>
+        </footer>
       </aside>
 
-      {/* Main content */}
+      {/* 메인 콘텐츠 영역 */}
       <div className="flex-1 flex flex-col">
-        <main className="flex-1 px-8 py-8 overflow-y-auto">{children}</main>
+        <main className="flex-1 px-8 py-8 overflow-y-auto" role="main">
+          {children}
+        </main>
       </div>
     </div>
   );

--- a/components/layout/SidebarMenuItem.jsx
+++ b/components/layout/SidebarMenuItem.jsx
@@ -1,6 +1,13 @@
 import Link from "next/link";
 import { cn } from "@/lib/shared/utils";
 
+/**
+ * SidebarMenuItem
+ * - 사이드바 내 단일 메뉴 항목 렌더링
+ * - 사이드바 열림 여부에 따라 라벨 토글
+ * - 활성화 여부에 따라 스타일 차별화
+ */
+
 export default function SidebarMenuItem({
   href,
   label,
@@ -17,8 +24,12 @@ export default function SidebarMenuItem({
           ? "bg-gray-900 text-white font-semibold"
           : "text-gray-700 hover:bg-gray-100"
       )}
+      title={label} // 사이드바 닫힌 상태에서도 접근성 확보
     >
+      {/* 아이콘 */}
       <Icon size={20} className="shrink-0" />
+
+      {/* 라벨 (사이드바 열림 여부에 따라 보여짐) */}
       <div
         className={cn(
           "ml-2 origin-left transition-all duration-200",

--- a/components/recommendation/RecommendationDetail.jsx
+++ b/components/recommendation/RecommendationDetail.jsx
@@ -18,6 +18,15 @@ import {
 } from "lucide-react";
 import FormActionButton from "@/components/common/button/FormActionButton";
 
+/**
+ * RecommendationDetail
+ * - 추천 여행지 상세 정보 뷰 컴포넌트
+ * - 이미지, 요약, 상세 설명, 위치 안내, 주변 정보 등 출력
+ * - ReactMarkdown으로 마크다운 설명 렌더링
+ * - 수정/삭제 버튼 포함
+ * - 접근성 및 시맨틱 태그 개선
+ */
+
 function RecommendationDetail({
   name,
   summary,
@@ -34,6 +43,7 @@ function RecommendationDetail({
   onDelete,
   loading,
 }) {
+  // 마크다운 스타일 컴포넌트 정의
   const markdownComponents = {
     p: ({ children }) => (
       <p className="text-gray-800 leading-relaxed mb-4">{children}</p>
@@ -54,8 +64,9 @@ function RecommendationDetail({
     "text-lg font-semibold text-gray-900 flex items-center gap-2";
 
   return (
-    <div className="w-full max-w-4xl mx-auto px-6 py-10 space-y-10">
-      <div>
+    <article className="w-full max-w-4xl mx-auto px-6 py-10 space-y-10">
+      {/* 목록으로 돌아가기 */}
+      <nav aria-label="뒤로가기 링크">
         <Link
           href="/admin/recommendation"
           className="inline-flex items-center text-sm text-gray-500 hover:underline"
@@ -63,14 +74,17 @@ function RecommendationDetail({
           <ArrowLeft className="w-4 h-4 mr-1" />
           목록으로 돌아가기
         </Link>
-      </div>
+      </nav>
 
-      {/* 기본 정보 */}
-      <div className="bg-white rounded-xl shadow p-6">
+      {/* 기본 정보 섹션 */}
+      <section
+        aria-labelledby="recommendation-heading"
+        className="bg-white rounded-xl shadow p-6"
+      >
         <div className="relative w-full h-[240px] sm:h-[280px] md:h-[320px] rounded-lg overflow-hidden">
           <Image
             src={imageUrl}
-            alt={name}
+            alt={`${name} 이미지`}
             fill
             className="object-cover"
             sizes="100vw"
@@ -78,9 +92,14 @@ function RecommendationDetail({
           />
         </div>
 
-        <div className="flex flex-col md:flex-row md:items-end justify-between gap-4 md:gap-6 mt-6">
+        <header className="flex flex-col md:flex-row md:items-end justify-between gap-4 md:gap-6 mt-6">
           <div className="flex-1 min-w-0 space-y-2">
-            <h1 className="text-3xl font-bold text-gray-900">{name}</h1>
+            <h1
+              id="recommendation-heading"
+              className="text-3xl font-bold text-gray-900"
+            >
+              {name}
+            </h1>
             <p className="text-gray-500 flex items-center gap-1 break-words">
               <MapPin className="w-4 h-4" />
               {location}
@@ -95,6 +114,7 @@ function RecommendationDetail({
                   ? "bg-green-100 text-green-700"
                   : "bg-gray-200 text-gray-600"
               }`}
+              aria-label={`노출 상태: ${visible ? "공개" : "비공개"}`}
             >
               {visible ? (
                 <>
@@ -106,6 +126,7 @@ function RecommendationDetail({
                 </>
               )}
             </span>
+
             <div className="text-xs text-gray-500 text-right space-y-1">
               <p className="flex items-center gap-1">
                 <CalendarDays className="w-3 h-3" />
@@ -122,13 +143,13 @@ function RecommendationDetail({
               )}
             </div>
           </div>
-        </div>
-      </div>
+        </header>
+      </section>
 
       {/* 상세 설명 */}
       {description && (
-        <div className={boxSection}>
-          <h2 className={sectionHeading}>
+        <section aria-labelledby="description-heading" className={boxSection}>
+          <h2 id="description-heading" className={sectionHeading}>
             <BookText className="w-5 h-5" /> 상세 설명
           </h2>
           <ReactMarkdown
@@ -137,13 +158,13 @@ function RecommendationDetail({
           >
             {description}
           </ReactMarkdown>
-        </div>
+        </section>
       )}
 
       {/* 위치 설명 */}
       {locationInfo && (
-        <div className={boxSection}>
-          <h2 className={sectionHeading}>
+        <section aria-labelledby="location-info-heading" className={boxSection}>
+          <h2 id="location-info-heading" className={sectionHeading}>
             <MapPin className="w-5 h-5" /> 위치 설명
           </h2>
           <ReactMarkdown
@@ -152,13 +173,13 @@ function RecommendationDetail({
           >
             {locationInfo}
           </ReactMarkdown>
-        </div>
+        </section>
       )}
 
       {/* 찾아가는 방법 */}
       {directions?.length > 0 && (
-        <div className={boxSection}>
-          <h2 className={sectionHeading}>
+        <section aria-labelledby="directions-heading" className={boxSection}>
+          <h2 id="directions-heading" className={sectionHeading}>
             <Navigation className="w-5 h-5" /> 찾아가는 방법
           </h2>
           <ReactMarkdown
@@ -167,13 +188,13 @@ function RecommendationDetail({
           >
             {directions.join("\n")}
           </ReactMarkdown>
-        </div>
+        </section>
       )}
 
       {/* 주변 정보 */}
       {nearbyInfo?.length > 0 && (
-        <div className={boxSection}>
-          <h2 className={sectionHeading}>
+        <section aria-labelledby="nearby-info-heading" className={boxSection}>
+          <h2 id="nearby-info-heading" className={sectionHeading}>
             <Landmark className="w-5 h-5" /> 주변 정보
           </h2>
           <ReactMarkdown
@@ -182,9 +203,10 @@ function RecommendationDetail({
           >
             {nearbyInfo.join("\n")}
           </ReactMarkdown>
-        </div>
+        </section>
       )}
 
+      {/* 액션 버튼 */}
       <div className="flex flex-row flex-wrap justify-end items-center gap-3 mt-8">
         <FormActionButton
           label="수정하기"
@@ -202,7 +224,7 @@ function RecommendationDetail({
           isLoading={loading}
         />
       </div>
-    </div>
+    </article>
   );
 }
 

--- a/components/recommendation/RecommendationDetailContainer.jsx
+++ b/components/recommendation/RecommendationDetailContainer.jsx
@@ -9,6 +9,14 @@ import LoadingSpinner from "@/components/common/loading/LoadingSpinner";
 import EmptyState from "@/components/common/feedback/EmptyState";
 import { AlertCircle } from "lucide-react";
 
+/**
+ * RecommendationDetailContainer
+ * - 추천 여행지 상세 정보를 가져와 <RecommendationDetail />에 전달하는 컨테이너 컴포넌트
+ * - id 쿼리 파라미터를 기준으로 여행지 데이터 fetch
+ * - 로딩/에러/삭제 핸들링 처리 포함
+ * - 수정 및 삭제 핸들러 정의 및 전달
+ */
+
 export default function RecommendationDetailContainer() {
   const router = useRouter();
   const { id } = router.query;

--- a/components/recommendation/RecommendationEditContainer.jsx
+++ b/components/recommendation/RecommendationEditContainer.jsx
@@ -10,6 +10,14 @@ import LoadingSpinner from "@/components/common/loading/LoadingSpinner";
 import EmptyState from "@/components/common/feedback/EmptyState";
 import { AlertCircle } from "lucide-react";
 
+/**
+ * RecommendationEditContainer
+ * - 추천 여행지 수정 페이지의 컨테이너 컴포넌트
+ * - URL의 id를 기준으로 여행지 데이터를 조회하여 폼에 초기값으로 전달
+ * - 이미지가 새로 업로드되면 스토리지에 업로드 후 해당 URL을 포함하여 수정 요청
+ * - 로딩, 데이터 없음, 폼 표시의 조건부 렌더링 처리 포함
+ */
+
 export default function RecommendationEditContainer() {
   const router = useRouter();
   const { id } = router.query;

--- a/components/recommendation/RecommendationForm.jsx
+++ b/components/recommendation/RecommendationForm.jsx
@@ -4,6 +4,14 @@ import FormTextarea from "@/components/common/form/FormTextarea";
 import FormSelect from "@/components/common/form/FormSelect";
 import FormSubmitButton from "@/components/common/button/FormSubmitButton";
 
+/**
+ * RecommendationForm
+ * - 추천 여행지 생성/수정 폼
+ * - 입력 상태(form), 이미지 변경, 제출 핸들러를 props로 받아 처리
+ * - 생성과 수정은 isEdit 여부로 분기 렌더링
+ * - 시맨틱 구조를 고려해 섹션 및 필드셋을 명확히 구분함
+ */
+
 function RecommendationForm({
   form,
   onChange,
@@ -18,8 +26,10 @@ function RecommendationForm({
       className="max-w-screen-lg mx-auto px-10 py-16 space-y-16"
     >
       {/* 1. 기본 정보 + 이미지 */}
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-12">
-        <div className="space-y-6">
+      <section className="grid grid-cols-1 lg:grid-cols-2 gap-12">
+        <fieldset className="space-y-6">
+          <legend className="sr-only">기본 정보 입력</legend>
+
           <FormInput
             label="장소명"
             value={form.name}
@@ -51,9 +61,11 @@ function RecommendationForm({
               { value: "제주도", label: "제주도" },
             ]}
           />
-        </div>
+        </fieldset>
 
-        <div className="space-y-6">
+        <fieldset className="space-y-6">
+          <legend className="sr-only">이미지 및 공개 여부</legend>
+
           <div>
             <label className="block text-base font-semibold text-gray-800 mb-2">
               대표 이미지
@@ -88,33 +100,38 @@ function RecommendationForm({
               체크 시 사용자에게 노출됩니다
             </span>
           </div>
-        </div>
-      </div>
+        </fieldset>
+      </section>
 
-      {/* 2. 상세 설명 */}
-      <div className="space-y-3">
-        <FormTextarea
-          id="description"
-          label="상세 설명"
-          value={form.description}
-          onChange={(e) => onChange("description", e.target.value)}
-          rows={20}
-        />
+      {/* 2. 상세 설명 및 위치 설명 */}
+      <section className="space-y-3">
+        <fieldset>
+          <legend className="sr-only">상세 설명</legend>
+          <FormTextarea
+            id="description"
+            label="상세 설명"
+            value={form.description}
+            onChange={(e) => onChange("description", e.target.value)}
+            rows={20}
+          />
+        </fieldset>
 
-        {/* 3. 위치 설명 */}
+        <fieldset>
+          <legend className="sr-only">위치 설명</legend>
+          <FormInput
+            id="locationInfo"
+            label="위치 설명"
+            type="text"
+            value={form.locationInfo}
+            onChange={(e) => onChange("locationInfo", e.target.value)}
+          />
+        </fieldset>
+      </section>
 
-        <FormInput
-          id="locationInfo"
-          label="위치 설명"
-          type="text"
-          value={form.locationInfo}
-          onChange={(e) => onChange("locationInfo", e.target.value)}
-        />
-      </div>
-
-      {/* 4. 찾아가는 방법 + 주변 정보 */}
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-12">
-        <div className="space-y-3">
+      {/* 3. 찾아가는 방법 + 주변 정보 */}
+      <section className="grid grid-cols-1 md:grid-cols-2 gap-12">
+        <fieldset className="space-y-3">
+          <legend className="sr-only">찾아가는 방법</legend>
           <FormTextarea
             id="direction"
             label="찾아가는 방법"
@@ -123,8 +140,10 @@ function RecommendationForm({
             placeholder="예: 제주국제공항에서 30분 소요"
             rows={10}
           />
-        </div>
-        <div className="space-y-3">
+        </fieldset>
+
+        <fieldset className="space-y-3">
+          <legend className="sr-only">주변 정보</legend>
           <FormTextarea
             id="nearby"
             label="주변 정보"
@@ -132,10 +151,10 @@ function RecommendationForm({
             onChange={(e) => onChange("nearby", e.target.value)}
             rows={10}
           />
-        </div>
-      </div>
+        </fieldset>
+      </section>
 
-      {/* 5. 버튼 */}
+      {/* 4. 제출 버튼 */}
       <div className="pt-10 border-t flex justify-end gap-3">
         {isEdit && (
           <button

--- a/components/recommendation/RecommendationFormContainer.jsx
+++ b/components/recommendation/RecommendationFormContainer.jsx
@@ -2,6 +2,14 @@ import { useCallback, useEffect, useState } from "react";
 import RecommendationForm from "@/components/recommendation/RecommendationForm";
 import { useFeedback } from "@/hooks/common/useFeedback";
 
+/**
+ * RecommendationFormContainer
+ * - 추천 여행지 생성/수정 폼의 상태를 관리하는 컨테이너 컴포넌트
+ * - 초기 값이 있을 경우 수정 폼으로, 없으면 신규 생성 폼으로 동작
+ * - 내부 상태: form 객체 (입력 필드 상태), image preview 관리
+ * - 제출 시 directions/nearbyInfo를 줄 단위 배열로 변환 후 상위 콜백 호출
+ */
+
 export default function RecommendationFormContainer({
   onSubmit,
   loading,
@@ -23,6 +31,7 @@ export default function RecommendationFormContainer({
   const [isInitialized, setIsInitialized] = useState(false);
   const { error } = useFeedback();
 
+  // 초기값이 있을 경우 수정 폼으로 세팅
   useEffect(() => {
     if (initialValues) {
       setForm({
@@ -43,6 +52,7 @@ export default function RecommendationFormContainer({
     }
   }, [initialValues]);
 
+  // Blob 이미지 주소 해제 (메모리 누수 방지)
   useEffect(() => {
     return () => {
       if (form.imagePreview?.startsWith("blob:")) {
@@ -72,6 +82,7 @@ export default function RecommendationFormContainer({
         return error("필수 항목을 모두 입력하세요.");
       }
 
+      // 줄바꿈 기준 배열 변환 후 상위 onSubmit 호출
       await onSubmit({
         ...form,
         directions: form.direction.split("\n").filter((l) => l.trim()),

--- a/components/recommendation/RecommendationList.jsx
+++ b/components/recommendation/RecommendationList.jsx
@@ -6,26 +6,35 @@ import EmptyState from "@/components/common/feedback/EmptyState";
 import { MapPin } from "lucide-react";
 import LoadingSpinner from "@/components/common/loading/LoadingSpinner";
 
+/**
+ * RecommendationList
+ * - 추천 여행지 목록을 카드 형태로 렌더링
+ * - 로딩 중에는 스피너 표시, 데이터 없을 경우 Empty 상태 출력
+ * - 각 아이템은 관리자 상세 페이지로 이동 가능한 링크 형태
+ */
+
 function RecommendationList({ recommendations, loading }) {
   if (loading || !recommendations) {
     return (
-      <div className="py-20">
+      <section className="py-20">
         <LoadingSpinner text="추천 여행지를 불러오는 중입니다..." />
-      </div>
+      </section>
     );
   }
 
   if (recommendations.length === 0) {
     return (
-      <EmptyState
-        message="등록된 추천 여행지가 없습니다."
-        icon={<MapPin className="w-8 h-8 text-gray-300 mb-2" />}
-      />
+      <section className="py-20">
+        <EmptyState
+          message="등록된 추천 여행지가 없습니다."
+          icon={<MapPin className="w-8 h-8 text-gray-300 mb-2" />}
+        />
+      </section>
     );
   }
 
   return (
-    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+    <section className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
       {recommendations.map((item) => (
         <Link
           key={item.id}
@@ -66,7 +75,7 @@ function RecommendationList({ recommendations, loading }) {
           </div>
         </Link>
       ))}
-    </div>
+    </section>
   );
 }
 

--- a/components/reports/chat/AdminChatReportsContainer.jsx
+++ b/components/reports/chat/AdminChatReportsContainer.jsx
@@ -8,10 +8,18 @@ import LoadingSpinner from "@/components/common/loading/LoadingSpinner";
 import ChatReportView from "@/components/reports/chat/ChatReportView";
 import { ADMIN_REPORTS } from "@/constants/queryKeys";
 
+/**
+ * AdminChatReportsContainer
+ * - 관리자 페이지에서 신고된 채팅 목록을 무한스크롤 방식으로 불러옴
+ * - 인증 완료 후 React Query 기반으로 데이터 요청
+ * - 선택된 신고는 상태로 관리하며, 상세 처리 후 리셋됨
+ */
+
 export default function AdminChatReportsContainer() {
   const { authReady, authUser, getToken } = useAdminAuth();
   const [selectedReport, setSelectedReport] = useState(null);
 
+  // 신고 목록 불러오기 (React Query - useInfiniteQuery)
   const {
     data,
     isLoading,
@@ -21,7 +29,7 @@ export default function AdminChatReportsContainer() {
     error,
   } = useInfiniteQuery({
     queryKey: ADMIN_REPORTS.CHAT,
-    enabled: authReady && !!authUser,
+    enabled: authReady && !!authUser, // 인증 완료 후 fetch
     queryFn: async ({ pageParam }) => {
       const token = await getToken();
       return await getAdminReports({
@@ -34,8 +42,10 @@ export default function AdminChatReportsContainer() {
       lastPage?.length === 50 ? lastPage[lastPage.length - 1]?.id : undefined,
   });
 
+  // 전체 신고 리스트 병합
   const reports = data?.pages.flat() || [];
 
+  // 처리 후 상세 선택 해제
   const handleReportSuccess = useCallback(() => {
     setSelectedReport(null);
   }, []);

--- a/components/reports/chat/ChatReportDetail.jsx
+++ b/components/reports/chat/ChatReportDetail.jsx
@@ -11,7 +11,16 @@ import {
   mutedTextClass,
 } from "@/styles/reportStyles";
 
+/**
+ * ChatReportDetail
+ * - 신고된 채팅 메시지의 상세 정보를 보여주는 컴포넌트
+ * - 좌측: 신고 정보 (사유, 신고자, 작성자, 신고일자)
+ * - 우측: 채팅 메시지 본문 표시
+ * - ActionButtons 포함: 처리 버튼 제공
+ */
+
 function ChatReportDetail({ report, onSuccess }) {
+  // 유효성 검사: 필수 필드 존재 여부 확인
   const isValidReport =
     typeof report === "object" &&
     report !== null &&

--- a/components/reports/chat/ChatReportTable.jsx
+++ b/components/reports/chat/ChatReportTable.jsx
@@ -3,7 +3,15 @@ import { format } from "date-fns";
 import { MessageSquareOff } from "lucide-react";
 import ReportTableLayout from "@/components/common/reports/ReportTableLayout";
 
+/**
+ * ChatReportTable
+ * - 신고된 채팅 메시지 목록을 테이블 형태로 표시하는 컴포넌트
+ * - ReportTableLayout을 기반으로 렌더링
+ * - 클릭 시 상세 정보 열람 가능 (onSelect)
+ */
+
 function ChatReportTable({ reports = [], onSelect }) {
+  // 테이블 행 구성: 각 신고 건에 대해 셀 배열 생성
   const rows = reports.map((report) => ({
     key: report.id,
     onClick: () => onSelect(report),
@@ -27,6 +35,7 @@ function ChatReportTable({ reports = [], onSelect }) {
     ],
   }));
 
+  // 테이블 헤더 정의
   const columns = [
     { header: "메시지 내용" },
     { header: "신고 사유" },

--- a/components/reports/chat/ChatReportView.jsx
+++ b/components/reports/chat/ChatReportView.jsx
@@ -4,6 +4,13 @@ import ChatReportDetail from "@/components/reports/chat/ChatReportDetail";
 import NoReportSelected from "@/components/common/feedback/NoReportSelected";
 import ReportListViewLayout from "@/components/common/reports/ReportListViewLayout";
 
+/**
+ * ChatReportView
+ * - 채팅 신고 목록 전체 뷰 컨테이너
+ * - 좌측: 신고 테이블, 우측: 선택된 신고 상세 보기
+ * - ReportListViewLayout을 사용하여 목록 + 상세 구조 구성
+ */
+
 function ChatReportView(props) {
   const {
     reports,

--- a/components/reports/review/AdminReviewReportsContainer.jsx
+++ b/components/reports/review/AdminReviewReportsContainer.jsx
@@ -8,6 +8,14 @@ import LoadingSpinner from "@/components/common/loading/LoadingSpinner";
 import ReviewReportView from "@/components/reports/review/ReviewReportView";
 import { ADMIN_REPORTS } from "@/constants/queryKeys";
 
+/**
+ * AdminReviewReportsContainer
+ * - 관리자 리뷰 신고 목록 컨테이너
+ * - 신고 목록 데이터를 무한 페이징 방식으로 불러옴 (useInfiniteQuery)
+ * - 선택된 신고는 ReviewReportView에 상세 전달
+ * - 성공 처리 시 상세 보기 초기화
+ */
+
 export default function AdminReviewReportsContainer() {
   const { authReady, authUser, getToken } = useAdminAuth();
   const [selectedReport, setSelectedReport] = useState(null);
@@ -21,7 +29,7 @@ export default function AdminReviewReportsContainer() {
     error,
   } = useInfiniteQuery({
     queryKey: ADMIN_REPORTS.REVIEW,
-    enabled: authReady && !!authUser,
+    enabled: authReady && !!authUser, // 인증 완료 후 쿼리 활성화
     queryFn: async ({ pageParam }) => {
       const token = await getToken();
       return await getAdminReports({
@@ -36,12 +44,15 @@ export default function AdminReviewReportsContainer() {
 
   const reports = data?.pages.flat() || [];
 
+  // 처리 완료 시 상세 보기 초기화
   const handleReportSuccess = useCallback(() => {
     setSelectedReport(null);
   }, []);
 
   if (isLoading || !authReady) {
-    return <LoadingSpinner text="신고된 리뷰를 불러오는 중..." />;
+    <section aria-label="리뷰 신고 목록 로딩 중">
+      <LoadingSpinner text="신고된 리뷰를 불러오는 중..." />
+    </section>;
   }
 
   return (

--- a/components/reports/review/ReviewReportDetail.jsx
+++ b/components/reports/review/ReviewReportDetail.jsx
@@ -9,17 +9,26 @@ import {
   mutedTextClass,
 } from "@/styles/reportStyles";
 
+/**
+ * ReviewReportDetail
+ * - 관리자 리뷰 신고 상세 뷰 컴포넌트
+ * - 신고 정보 및 연결된 리뷰 데이터를 표시
+ * - 삭제된 리뷰인 경우 예외 처리
+ */
+
 function ReviewReportDetail({ report, onSuccess }) {
   const isValidReport =
     typeof report === "object" && typeof report.reason === "string";
 
   const { review, reason, reporterId } = report;
 
+  // 인터뷰 Q&A 리스트 생성 (Object.entries)
   const interviewList = useMemo(() => {
     if (!review?.interviewAnswers) return null;
     return Object.entries(review.interviewAnswers);
   }, [review]);
 
+  // 유효하지 않은 신고 데이터 처리
   if (!isValidReport) {
     return (
       <div className="p-6 text-sm text-red-400 text-center" role="alert">

--- a/components/reports/review/ReviewReportTable.jsx
+++ b/components/reports/review/ReviewReportTable.jsx
@@ -3,7 +3,15 @@ import { format } from "date-fns";
 import { FileWarning } from "lucide-react";
 import ReportTableLayout from "@/components/common/reports/ReportTableLayout";
 
+/**
+ * ReviewReportTable
+ * - 리뷰 신고 목록 테이블 컴포넌트
+ * - 각 신고 항목을 테이블 형식으로 렌더링
+ * - 클릭 시 상세보기로 이동 (onSelect)
+ */
+
 function ReviewReportTable({ reports = [], onSelect }) {
+  // 테이블 각 행(row) 구성
   const rows = reports.map((report) => ({
     key: report.id,
     onClick: () => onSelect(report),
@@ -27,6 +35,7 @@ function ReviewReportTable({ reports = [], onSelect }) {
     ],
   }));
 
+  // 테이블 컬럼 정의
   const columns = [
     { header: "리뷰 제목" },
     { header: "신고 사유" },

--- a/components/reports/review/ReviewReportView.jsx
+++ b/components/reports/review/ReviewReportView.jsx
@@ -4,6 +4,13 @@ import ReviewReportDetail from "@/components/reports/review/ReviewReportDetail";
 import NoReportSelected from "@/components/common/feedback/NoReportSelected";
 import ReportListViewLayout from "@/components/common/reports/ReportListViewLayout";
 
+/**
+ * ReviewReportView
+ * - 리뷰 신고 목록 뷰의 전체 레이아웃 구성
+ * - 테이블 + 상세 보기 + 페이징 + 에러/빈 상태 처리
+ * - 선택된 신고 데이터를 상세 컴포넌트에 전달
+ */
+
 function ReviewReportView(props) {
   const {
     reports,

--- a/components/users/StatusBadge.jsx
+++ b/components/users/StatusBadge.jsx
@@ -1,5 +1,11 @@
 import React from "react";
 
+/**
+ * StatusBadge
+ * - 사용자 상태(active, banned, dormant)에 따라 뱃지 스타일 및 라벨을 출력
+ * - 시각적으로 상태를 구분하여 관리자 UI의 가독성을 높임
+ */
+
 function StatusBadge({ status }) {
   const variant = {
     active: "bg-green-100 text-green-800",

--- a/components/users/UserActionButtons.jsx
+++ b/components/users/UserActionButtons.jsx
@@ -3,6 +3,13 @@ import { PauseCircle, Trash2, RotateCcw } from "lucide-react";
 import { changeAdminUserStatus, deleteUser } from "@/lib/admin/userActions";
 import { updateUserStatus } from "@/lib/server/users";
 
+/**
+ * UserActionButtons
+ * - 관리자 페이지 사용자 행위 제어 버튼 모음 (계정 정지, 복구, 삭제)
+ * - 계정 상태에 따라 버튼 비활성화 조건을 제어
+ * - 액션 처리 후 상위 컴포넌트에 성공 콜백 전달
+ */
+
 function UserActionButtons({ userId, currentStatus, onSuccess }) {
   const isBanned = currentStatus === "banned";
 
@@ -25,6 +32,7 @@ function UserActionButtons({ userId, currentStatus, onSuccess }) {
 
   return (
     <div className="flex items-center justify-center space-x-2">
+      {/* 계정 복구 버튼 (정지 상태일 때만 활성화) */}
       <button
         onClick={() =>
           handleAction({
@@ -45,6 +53,7 @@ function UserActionButtons({ userId, currentStatus, onSuccess }) {
         <RotateCcw size={16} strokeWidth={1.8} />
       </button>
 
+      {/* 계정 정지 버튼 (이미 정지된 경우 비활성화) */}
       <button
         onClick={() =>
           handleAction({
@@ -66,6 +75,7 @@ function UserActionButtons({ userId, currentStatus, onSuccess }) {
         <PauseCircle size={16} strokeWidth={1.8} />
       </button>
 
+      {/* 계정 삭제 버튼 (항상 활성화됨, 복구 불가) */}
       <button
         onClick={() =>
           handleAction({

--- a/components/users/UserFilterBar.jsx
+++ b/components/users/UserFilterBar.jsx
@@ -2,6 +2,13 @@ import React from "react";
 import { Download, Filter } from "lucide-react";
 import FormSelect from "@/components/common/form/FormSelect";
 
+/**
+ * UserFilterBar
+ * - 사용자 목록 페이지에서 필터링, 정렬, 내보내기 등의 UI 제어 바
+ * - 상태 / 가입일 / 정렬 기준 필터 제공
+ * - 필터 초기화 및 사용자 목록 내보내기 기능 포함
+ */
+
 function UserFilterBar({ filters, onChange, onReset, onExport }) {
   return (
     <div className="bg-white rounded-xl shadow-sm p-4 mb-6 flex flex-wrap justify-between items-center gap-4">
@@ -48,7 +55,7 @@ function UserFilterBar({ filters, onChange, onReset, onExport }) {
 
       {/* 오른쪽: 버튼 그룹 */}
       <div className="flex items-center gap-2">
-        {/* 필터 초기화 */}
+        {/* 필터 초기화 버튼 */}
         <button
           onClick={onReset}
           className="flex items-center gap-1 bg-gray-100 border border-gray-300 text-gray-600 rounded-md px-3 py-2 text-sm h-10 hover:bg-gray-200"
@@ -57,7 +64,7 @@ function UserFilterBar({ filters, onChange, onReset, onExport }) {
           <span>필터 초기화</span>
         </button>
 
-        {/* 사용자 목록 내보내기 */}
+        {/* 사용자 목록 내보내기 버튼 */}
         <button
           onClick={onExport}
           className="flex items-center gap-1 bg-black text-white rounded-md px-4 py-2 text-sm h-10 hover:opacity-80"

--- a/components/users/UserSearchInput.jsx
+++ b/components/users/UserSearchInput.jsx
@@ -1,16 +1,22 @@
 import React from "react";
 import { Search } from "lucide-react";
 
+/**
+ * UserSearchInput
+ * - 사용자 목록에서 닉네임 또는 이메일로 검색하는 인풋 컴포넌트
+ * - 검색 아이콘과 함께 입력창을 제공하며, 입력 값은 부모 컴포넌트로 전달됨
+ */
+
 function UserSearchInput({ value, onChange }) {
   return (
     <div className="relative w-full sm:w-auto">
-      {/* 아이콘 */}
+      {/* 검색 아이콘 */}
       <Search
         size={16}
         className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400 pointer-events-none"
       />
 
-      {/* 입력창 */}
+      {/* 검색 입력창 */}
       <input
         type="text"
         placeholder="닉네임 또는 이메일 검색"

--- a/components/users/UserTable.jsx
+++ b/components/users/UserTable.jsx
@@ -4,6 +4,14 @@ import { formatDateKR } from "@/lib/shared/date";
 import StatusBadge from "@/components/users/StatusBadge";
 import SkeletonImage from "@/components/common/loading/SkeletonImage";
 
+/**
+ * UserTable
+ * - 관리자 페이지에서 사용자 목록을 테이블 형태로 렌더링
+ * - 사용자 프로필, 가입일, 작성 일정/리뷰 수, 신고 이력, 상태, 액션 버튼 포함
+ * - SkeletonImage를 사용해 fallback 이미지 처리 및 안정적인 렌더링 제공
+ * - 상태 뱃지(StatusBadge)와 액션 버튼(UserActionButtons) 포함
+ */
+
 function UserTable({ users, onReload }) {
   const headerBase = "px-4 py-3";
   const headerLeft = `${headerBase} text-left`;
@@ -13,7 +21,7 @@ function UserTable({ users, onReload }) {
   const cellCenter = `${cellBase} text-center`;
 
   return (
-    <div className="bg-white rounded-xl shadow-sm overflow-x-auto">
+    <section className="bg-white rounded-xl shadow-sm overflow-x-auto">
       <table className="min-w-[800px] w-full text-sm">
         <thead className="bg-gray-50 text-xs text-gray-500 uppercase">
           <tr>
@@ -26,6 +34,7 @@ function UserTable({ users, onReload }) {
             <th className={headerCenter}>액션</th>
           </tr>
         </thead>
+
         <tbody className="divide-y divide-gray-100">
           {users.map((user) => (
             <tr key={user.id} className="hover:bg-gray-50 transition">
@@ -93,7 +102,7 @@ function UserTable({ users, onReload }) {
           ))}
         </tbody>
       </table>
-    </div>
+    </section>
   );
 }
 

--- a/components/users/UserTableContainer.jsx
+++ b/components/users/UserTableContainer.jsx
@@ -9,6 +9,13 @@ import LoadingSpinner from "@/components/common/loading/LoadingSpinner";
 import EmptyState from "@/components/common/feedback/EmptyState";
 import { Inbox } from "lucide-react";
 
+/**
+ * UserTableContainer
+ * - 관리자 페이지 사용자 관리의 컨테이너 컴포넌트
+ * - 사용자 목록 조회, 필터링, 검색, CSV 내보내기, 페이징 처리 포함
+ * - 상태는 local state로 관리하며 비동기 fetchUsers 기반으로 데이터 로딩
+ */
+
 export default function UserTableContainer() {
   const [users, setUsers] = useState([]);
   const [loading, setLoading] = useState(true);
@@ -23,6 +30,7 @@ export default function UserTableContainer() {
   const usersPerPage = 5;
   const isInitialEmpty = users.length === 0;
 
+  // 사용자 데이터 fetch 함수
   const loadUsers = useCallback(async (customFilters) => {
     try {
       const data = await fetchUsers(customFilters);
@@ -32,6 +40,7 @@ export default function UserTableContainer() {
     }
   }, []);
 
+  // 필터 변경 시 사용자 데이터 로드
   useEffect(() => {
     setLoading(true);
     loadUsers(filters).finally(() => setLoading(false));
@@ -42,6 +51,7 @@ export default function UserTableContainer() {
     setFilters((prev) => ({ ...prev, [key]: value }));
   }, []);
 
+  // 필터 초기화
   const handleFilterReset = useCallback(() => {
     setFilters({ status: "all", date: "all", sort: "recent" });
   }, []);
@@ -54,6 +64,7 @@ export default function UserTableContainer() {
     );
   }, [users, search]);
 
+  // CSV 내보내기 처리
   const handleExport = useCallback(() => {
     if (!filteredUsers || filteredUsers.length === 0) return;
 
@@ -75,16 +86,14 @@ export default function UserTableContainer() {
     exportToCSV("loneleap_users", exportData);
   }, [filteredUsers]);
 
-  // 필터링 + 검색
-
-  // 현재 페이지 데이터
+  // 현재 페이지의 사용자 데이터 추출
   const currentUsers = useMemo(() => {
     const startIndex = (currentPage - 1) * usersPerPage;
     const endIndex = startIndex + usersPerPage;
     return filteredUsers.slice(startIndex, endIndex);
   }, [filteredUsers, currentPage, usersPerPage]);
 
-  // 필터/검색 변경 시 페이지 초기화
+  // 필터 또는 검색 변경 시 페이지 초기화
   useEffect(() => {
     setCurrentPage(1);
   }, [filters, search]);

--- a/context/auth/useAdminAuth.js
+++ b/context/auth/useAdminAuth.js
@@ -2,6 +2,13 @@ import { createContext, useContext, useEffect, useState } from "react";
 import { onAuthStateChanged } from "firebase/auth";
 import { auth } from "@/lib/firebase/client";
 
+/**
+ * 관리자 인증 컨텍스트를 제공하는 Provider 컴포넌트
+ * - Firebase Auth의 상태를 감지하여 인증 사용자 정보를 전역에서 공유
+ * - 초기 로딩 여부(authReady)와 현재 로그인된 사용자(authUser)를 상태로 관리
+ * - 필요한 경우 사용자 ID 토큰을 가져오는 getToken 함수 제공
+ */
+
 const AdminAuthContext = createContext();
 
 export function AdminAuthProvider({ children }) {
@@ -9,6 +16,7 @@ export function AdminAuthProvider({ children }) {
   const [authUser, setAuthUser] = useState(null);
 
   useEffect(() => {
+    // Firebase 인증 상태 감지: 로그인/로그아웃 시 상태 자동 반영
     const unsubscribe = onAuthStateChanged(auth, (user) => {
       setAuthUser(user);
       setAuthReady(true);
@@ -16,6 +24,10 @@ export function AdminAuthProvider({ children }) {
     return () => unsubscribe();
   }, []);
 
+  /**
+   * 현재 로그인된 사용자의 Firebase ID 토큰을 반환
+   * - API 요청 시 인증 헤더로 사용
+   */
   const getToken = async () => {
     if (!authUser) return null;
     return await authUser.getIdToken();
@@ -27,6 +39,11 @@ export function AdminAuthProvider({ children }) {
     </AdminAuthContext.Provider>
   );
 }
+
+/**
+ * 관리자 인증 컨텍스트를 사용하는 커스텀 훅
+ * - 전역 인증 상태(authReady, authUser, getToken)를 반환
+ */
 
 export function useAdminAuth() {
   return useContext(AdminAuthContext);

--- a/hooks/common/useFeedback.js
+++ b/hooks/common/useFeedback.js
@@ -1,3 +1,14 @@
+/**
+ * 공통 피드백 메시지 훅
+ * - 사용자에게 알림(alert)을 통해 성공 또는 오류 메시지를 표시하는 유틸리티 훅
+ * - 에러 로그는 콘솔에 출력하고, 사용자에겐 fallback 메시지 또는 에러 메시지를 보여줌
+ *
+ * 사용 예:
+ * const { success, error } = useFeedback();
+ * success("작업이 완료되었습니다.");
+ * error(err, "저장 중 오류가 발생했습니다.");
+ */
+
 export function useFeedback() {
   const success = (message) => {
     alert(message);

--- a/hooks/recommendation/useAddRecommendation.js
+++ b/hooks/recommendation/useAddRecommendation.js
@@ -7,6 +7,12 @@ import { useMutation } from "@tanstack/react-query";
 import { addRecommendationToFirestore } from "@/services/addRecommendation";
 import { useFeedback } from "@/hooks/common/useFeedback";
 
+/**
+ * 추천 여행지 등록 훅
+ * - 이미지 업로드 후 Firestore에 추천 여행지 데이터 저장
+ * - 성공 시 알림 후 추천 목록 페이지로 이동
+ */
+
 export function useAddRecommendation() {
   const { uploadImage } = useUploadImage();
   const router = useRouter();

--- a/hooks/recommendation/useDeleteRecommendation.js
+++ b/hooks/recommendation/useDeleteRecommendation.js
@@ -4,6 +4,12 @@ import { useMutation } from "@tanstack/react-query";
 import { deleteRecommendationFromFirestore } from "@/services/deleteRecommendation";
 import { useFeedback } from "@/hooks/common/useFeedback";
 
+/**
+ * 추천 여행지 삭제 훅
+ * - Firestore에서 해당 추천 데이터를 삭제
+ * - 성공 시 알림, 실패 시 에러 핸들링
+ */
+
 export function useDeleteRecommendation() {
   const { success, error } = useFeedback();
 

--- a/hooks/recommendation/useFetchRecommendations.js
+++ b/hooks/recommendation/useFetchRecommendations.js
@@ -4,6 +4,12 @@ import { useQuery } from "@tanstack/react-query";
 import { fetchRecommendationsFromFirestore } from "@/services/fetchRecommendations";
 import { RECOMMENDATIONS } from "@/constants/queryKeys";
 
+/**
+ * 추천 여행지 전체 목록 조회 훅
+ * - Firestore에서 추천 여행지 리스트를 불러옴
+ * - 5분간 fresh 상태 유지 (staleTime: 5분)
+ */
+
 export function useFetchRecommendations() {
   const { data, isLoading, isError, error } = useQuery({
     queryKey: [RECOMMENDATIONS.LIST],

--- a/hooks/recommendation/useRecommendationDetail.js
+++ b/hooks/recommendation/useRecommendationDetail.js
@@ -4,6 +4,13 @@ import { useQuery } from "@tanstack/react-query";
 import { getRecommendationDetail } from "@/services/getRecommendationDetail";
 import { RECOMMENDATIONS } from "@/constants/queryKeys";
 
+/**
+ * 추천 여행지 상세 조회 훅
+ * - ID 기반으로 단일 여행지 정보 조회
+ * - ID가 없으면 요청하지 않음 (enabled 조건)
+ * - 404 대응을 위해 retry 비활성화
+ */
+
 export function useRecommendationDetail(id) {
   const { data, isLoading, isError } = useQuery({
     queryKey: RECOMMENDATIONS.DETAIL(id),

--- a/hooks/recommendation/useUpdateRecommendation.js
+++ b/hooks/recommendation/useUpdateRecommendation.js
@@ -6,6 +6,13 @@ import { useRouter } from "next/router";
 import { useFeedback } from "@/hooks/common/useFeedback";
 import { RECOMMENDATIONS } from "@/constants/queryKeys";
 
+/**
+ * 추천 여행지 수정 훅
+ * - Firestore의 특정 추천 항목 수정
+ * - 성공 시 목록 및 상세 쿼리 무효화 → 데이터 최신화
+ * - 수정 완료 후 목록 페이지로 이동
+ */
+
 export function useUpdateRecommendation() {
   const router = useRouter();
   const queryClient = useQueryClient();

--- a/hooks/useUploadImage.js
+++ b/hooks/useUploadImage.js
@@ -1,6 +1,18 @@
 import { useCallback, useState } from "react";
 import { uploadImage } from "@/lib/firebase/uploadImage";
 
+/**
+ * 이미지 업로드 훅
+ * - Firebase Storage에 이미지 파일을 업로드하고 URL을 반환
+ * - 업로드 중 상태(uploading), 에러 상태(error) 제공
+ *
+ * @returns {{
+ *   uploadImage: (file: File, folder?: string) => Promise<string | null>,
+ *   uploading: boolean,
+ *   error: Error | null
+ * }}
+ */
+
 export function useUploadImage() {
   const [uploading, setUploading] = useState(false);
   const [error, setError] = useState(null);

--- a/lib/admin/userActions.js
+++ b/lib/admin/userActions.js
@@ -1,3 +1,14 @@
+/**
+ * 사용자 상태 변경 (관리자 전용)
+ *
+ * 지정한 사용자 UID에 대해 'active', 'banned' 등 상태를 변경하는 API 요청을 수행합니다.
+ *
+ * @param {string} uid - 상태를 변경할 사용자 UID
+ * @param {string} status - 설정할 상태값 ('active', 'banned' 등)
+ * @returns {Promise<Object>} - 변경된 사용자 정보 객체
+ * @throws {Error} - 요청 실패 시 에러 메시지를 포함한 예외를 발생시킴
+ */
+
 export const changeAdminUserStatus = async (uid, status) => {
   const res = await fetch(`/api/admin/users/${uid}`, {
     method: "PATCH",
@@ -9,6 +20,16 @@ export const changeAdminUserStatus = async (uid, status) => {
   if (!res.ok) throw new Error(data.error || `상태 변경 실패 (${status})`);
   return data;
 };
+
+/**
+ * 사용자 계정 삭제 (관리자 전용)
+ *
+ * 지정한 사용자 UID에 대해 계정 삭제 API 요청을 수행합니다. 되돌릴 수 없는 작업이므로 주의가 필요합니다.
+ *
+ * @param {string} uid - 삭제할 사용자 UID
+ * @returns {Promise<Object>} - 삭제 결과를 담은 응답 객체
+ * @throws {Error} - 요청 실패 시 에러 메시지를 포함한 예외를 발생시킴
+ */
 
 export const deleteUser = async (uid) => {
   const res = await fetch(`/api/admin/users/${uid}`, {

--- a/lib/firebase/admin.js
+++ b/lib/firebase/admin.js
@@ -1,5 +1,15 @@
 import admin from "firebase-admin";
 
+/**
+ * Firebase Admin SDK 초기화 및 인증/DB 인스턴스 제공 모듈
+ *
+ * - 서버 환경에서 Firebase 인증 및 Firestore 접근을 위한 Admin SDK 설정
+ * - 앱이 이미 초기화된 경우 중복 초기화 방지
+ * - 환경변수 기반으로 서비스 계정 인증 처리
+ *
+ * @module firebaseAdmin
+ */
+
 if (!admin.apps.length) {
   admin.initializeApp({
     credential: admin.credential.cert({

--- a/lib/firebase/client.js
+++ b/lib/firebase/client.js
@@ -3,6 +3,16 @@ import { getAuth } from "firebase/auth";
 import { getFirestore } from "firebase/firestore";
 import { getStorage } from "firebase/storage";
 
+/**
+ * 클라이언트 측 Firebase 초기화 모듈
+ *
+ * - Firebase Web SDK를 기반으로 클라이언트 앱에서 Firebase 서비스(auth, db, storage)를 초기화
+ * - `getApps()`를 통해 중복 초기화를 방지하고, 이미 초기화된 앱을 재사용
+ * - 환경변수(`NEXT_PUBLIC_*`) 기반 설정 사용
+ *
+ * @module firebaseClient
+ */
+
 const firebaseConfig = {
   apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY,
   authDomain: process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN,

--- a/lib/firebase/uploadImage.js
+++ b/lib/firebase/uploadImage.js
@@ -2,6 +2,17 @@ import { ref, uploadBytes, getDownloadURL } from "firebase/storage";
 import { storage } from "@/lib/firebase/client";
 import { v4 as uuid } from "uuid";
 
+/**
+ * Firebase Storage에 이미지를 업로드하고 다운로드 URL을 반환합니다.
+ *
+ * 파일명을 UUID 기반으로 고유하게 설정하여 저장하며, 업로드 완료 후 접근 가능한 URL을 반환합니다.
+ *
+ * @param {File} file - 업로드할 이미지 파일 객체
+ * @param {string} [folder="recommendations"] - 저장할 폴더 경로 (기본값: 'recommendations')
+ * @returns {Promise<string>} - 업로드된 이미지의 다운로드 URL
+ * @throws {Error} - 업로드 실패 시 예외 발생
+ */
+
 export async function uploadImage(file, folder = "recommendations") {
   const fileRef = ref(storage, `${folder}/${uuid()}_${file.name}`);
   const snapshot = await uploadBytes(fileRef, file);

--- a/lib/server/auth.js
+++ b/lib/server/auth.js
@@ -1,5 +1,11 @@
 import { getAuth } from "firebase-admin/auth";
-import { destroyCookie } from "nookies";
+
+/**
+ * 요청 헤더의 Firebase ID 토큰을 검증하고, 관리자인 경우 디코딩된 토큰을 반환합니다.
+ *
+ * @param {import("next").NextApiRequest} req - Next.js API 요청 객체
+ * @returns {Promise<import("firebase-admin").auth.DecodedIdToken|null>} - 유효한 관리자 토큰 또는 null
+ */
 
 export async function verifyAdminToken(req) {
   try {
@@ -27,10 +33,4 @@ export async function verifyAdminToken(req) {
     console.error("[auth] verifyIdToken 실패:", error.code, error.message);
     return null; // 어떤 오류든 일단 null로 처리 (500 방지)
   }
-}
-
-export function clearAuthCookie(ctx = null) {
-  destroyCookie(ctx, "admin-auth-token", {
-    path: "/",
-  });
 }

--- a/lib/server/cookies.js
+++ b/lib/server/cookies.js
@@ -1,5 +1,11 @@
 import { destroyCookie } from "nookies";
 
+/**
+ * 관리자 인증 쿠키를 삭제합니다. 로그아웃 시 사용됩니다.
+ *
+ * @param {import("next").NextApiContext | null} ctx - Next.js API 또는 페이지 컨텍스트 (서버/클라이언트 구분용)
+ */
+
 export function clearAuthCookie(ctx = null) {
   destroyCookie(ctx, "admin-auth-token", {
     path: "/",

--- a/lib/server/dashboard/getAdminDashboardData.js
+++ b/lib/server/dashboard/getAdminDashboardData.js
@@ -3,6 +3,13 @@ import { getChartData } from "@/lib/server/dashboard/getChartData";
 import { getRecentReports } from "@/lib/server/dashboard/getRecentReports";
 import { getReporterEmailMap } from "@/lib/server/dashboard/getReporterEmailMap";
 
+/**
+ * 관리자 대시보드에서 사용할 통계, 차트 데이터, 최근 신고 내역을 병렬로 가져옵니다.
+ * Firestore에서 데이터를 읽고 reporterId를 이메일로 매핑한 결과를 포함합니다.
+ *
+ * @returns {Promise<{ props: { stats: object|null, chartData: object|null, recentReports: Array, error?: string } }>}
+ */
+
 export async function getAdminDashboardData() {
   try {
     const { db } = await import("@/lib/firebase/admin");

--- a/lib/server/dashboard/getChartData.js
+++ b/lib/server/dashboard/getChartData.js
@@ -2,6 +2,18 @@ import dayjs from "dayjs";
 import { aggregateReportsByDate } from "@/utils/aggregateReportsByDate";
 import { aggregateReportsByMonth } from "@/utils/aggregateReportsByMonth";
 
+/**
+ * 최근 7일간의 신고 추이, 유저 상태 분포, 최근 6개월간의 활동량(리뷰/일정)을 집계하여 반환합니다.
+ *
+ * @param {FirebaseFirestore.Firestore} db - Firebase Admin SDK의 Firestore 인스턴스
+ * @returns {Promise<{
+ *   reviewReports: Array,
+ *   chatReports: Array,
+ *   userStatusDist: Array<{ status: string, count: number }>,
+ *   activityByMonth: Array<{ month: string, reviews: number, itineraries: number }>
+ * }>}
+ */
+
 export async function getChartData(db) {
   const today = dayjs().endOf("day");
   const sevenDaysAgo = today.subtract(6, "day").startOf("day");

--- a/lib/server/dashboard/getRecentReports.js
+++ b/lib/server/dashboard/getRecentReports.js
@@ -1,3 +1,17 @@
+/**
+ * 최근 5개의 리뷰 및 채팅 신고 데이터를 가져와 시간순으로 정렬하여 반환합니다.
+ * 신고자는 reporterId로만 반환됩니다 (이메일 매핑은 getReporterEmailMap에서 수행).
+ *
+ * @param {FirebaseFirestore.Firestore} db - Firebase Admin SDK의 Firestore 인스턴스
+ * @returns {Promise<Array<{
+ *   id: string,
+ *   type: "리뷰" | "채팅",
+ *   reason: string,
+ *   reporterId: string,
+ *   reportedAt: string | null
+ * }>>}
+ */
+
 export async function getRecentReports(db) {
   const [reviewDocs, chatDocs] = await Promise.all([
     db

--- a/lib/server/dashboard/getReporterEmailMap.js
+++ b/lib/server/dashboard/getReporterEmailMap.js
@@ -1,3 +1,12 @@
+/**
+ * reporterId(uid) 리스트를 받아 해당 유저의 이메일을 매핑하여 반환합니다.
+ * users 컬렉션에 없을 경우 Firebase Auth에서 직접 조회하거나 '탈퇴한 사용자'로 처리합니다.
+ *
+ * @param {FirebaseFirestore.Firestore} db - Firestore 인스턴스
+ * @param {Set<string>} ids - UID 문자열 Set
+ * @returns {Promise<Record<string, string>>} - UID → 이메일 매핑 객체
+ */
+
 export async function getReporterEmailMap(db, ids) {
   const { getAuth } = await import("firebase-admin/auth");
   const emailMap = {};

--- a/lib/server/dashboard/getStats.js
+++ b/lib/server/dashboard/getStats.js
@@ -1,3 +1,10 @@
+/**
+ * 전체 리뷰 신고 수, 채팅 신고 수, 활성 사용자 수를 count 쿼리로 가져옵니다.
+ *
+ * @param {FirebaseFirestore.Firestore} db - Firestore 인스턴스
+ * @returns {Promise<{ reviewReports: number, chatReports: number, activeUsers: number }>}
+ */
+
 export async function getStats(db) {
   const [reviewCountSnap, chatCountSnap, activeUserCountSnap] =
     await Promise.all([

--- a/lib/server/deleteUserData.js
+++ b/lib/server/deleteUserData.js
@@ -1,9 +1,19 @@
 import { db, adminAuth } from "@/lib/firebase/admin";
 
 /**
- * 관리자 또는 사용자 탈퇴 시, 계정과 관련된 모든 데이터 삭제
- * @param {string} uid - 삭제할 유저의 UID
+ * 주어진 UID를 가진 사용자의 모든 데이터를 Firestore 및 Firebase Auth에서 삭제합니다.
+ *
+ * 삭제 항목:
+ * - users_private / users_public 문서
+ * - 생성한 일정, 리뷰, 채팅방, 채팅 메시지
+ * - 작성한 리뷰/채팅 신고
+ * - Firebase Auth 계정
+ *
+ * @param {string} uid - 삭제할 사용자 UID
+ * @returns {Promise<{ success: boolean }>} - 성공 여부 반환
+ * @throws {Error} - 삭제 실패 시 에러 발생
  */
+
 export default async function deleteUserData(uid) {
   if (!uid) throw new Error("UID 누락");
 

--- a/lib/server/users.js
+++ b/lib/server/users.js
@@ -12,8 +12,16 @@ import {
 import { db } from "@/lib/firebase/client";
 
 /**
- * users_public + users_private 병합된 사용자 목록 조회
+ * users_private 및 users_public 컬렉션을 병합하여 사용자 목록을 반환합니다.
+ * 필터 및 정렬 옵션을 적용할 수 있습니다.
+ *
+ * @param {Object} filters - 필터 객체 (status, date, sort)
+ * @param {string} [filters.status] - 유저 상태 필터 ("all" | "active" | "suspended")
+ * @param {string} [filters.date] - 가입일 필터 ("7days" | "30days")
+ * @param {string} [filters.sort] - 정렬 기준 ("latest" | "oldest" | "review" | "itinerary")
+ * @returns {Promise<Array<Object>>} - 병합된 사용자 데이터 리스트
  */
+
 export async function fetchUsers(filters = {}) {
   try {
     const privateRef = collection(db, "users_private");
@@ -83,11 +91,26 @@ export async function fetchUsers(filters = {}) {
   }
 }
 
-// 사용자 상태 업데이트 함수
+/**
+ * users_private 컬렉션의 사용자 상태 필드를 업데이트합니다.
+ *
+ * @param {string} uid - 사용자 UID
+ * @param {string} status - 새 상태 ("active" | "suspended" 등)
+ * @returns {Promise<void>}
+ */
+
 export const updateUserStatus = async (uid, status) => {
   const userRef = doc(db, "users_private", uid);
   await updateDoc(userRef, { status });
 };
+
+/**
+ * Firestore에서 사용자 계정 문서(users_private, users_public)를 삭제합니다.
+ * Firebase Auth 계정 삭제는 포함하지 않습니다.
+ *
+ * @param {string} uid - 사용자 UID
+ * @returns {Promise<void>}
+ */
 
 export const deleteUserAccount = async (uid) => {
   const privateRef = doc(db, "users_private", uid);

--- a/lib/shared/date.js
+++ b/lib/shared/date.js
@@ -1,3 +1,12 @@
+/**
+ * 다양한 날짜 입력 값을 한국어(KR) 로케일 기준의 날짜 문자열로 포맷팅합니다.
+ * - 입력이 없거나 유효하지 않을 경우 "N/A"를 반환합니다.
+ * - 문자열, Date 객체, Firestore Timestamp 모두 처리 가능합니다.
+ *
+ * @param {string | Date | { toDate: () => Date }} input - 날짜 문자열, Date 객체, 또는 Firestore Timestamp
+ * @returns {string} - "YYYY.MM.DD HH:MM" 형식의 날짜 문자열 (예: 2025.06.08 14:30)
+ */
+
 export function formatDateKR(input) {
   if (!input) return "N/A";
   const date =

--- a/pages/admin/index.js
+++ b/pages/admin/index.js
@@ -1,6 +1,12 @@
 import { getAdminDashboardData } from "@/lib/server/dashboard/getAdminDashboardData";
 import AdminDashboardContainer from "@/components/dashboard/AdminDashboardContainer";
 
+/**
+ * AdminDashboardPage
+ * - 관리자 대시보드 페이지 (SSR)
+ * - 통계 카드, 차트, 신고 목록 등을 렌더링
+ */
+
 export const getServerSideProps = getAdminDashboardData;
 
 function AdminDashboardPage(props) {

--- a/pages/admin/login/index.js
+++ b/pages/admin/login/index.js
@@ -2,6 +2,13 @@ import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
 import AdminLoginFormContainer from "@/components/auth/AdminLoginFormContainer";
 
+/**
+ * AdminLoginPage
+ * - 관리자 로그인 폼 페이지
+ * - 쿼리 파라미터에 따라 에러 메시지 처리
+ * - router.asPath를 key로 사용해 리렌더링 유도
+ */
+
 export default function AdminLoginPage() {
   const router = useRouter();
   const [error, setError] = useState("");

--- a/pages/admin/recommendation/index.js
+++ b/pages/admin/recommendation/index.js
@@ -4,6 +4,12 @@ import { useFetchRecommendations } from "@/hooks/recommendation/useFetchRecommen
 import RecommendationList from "@/components/recommendation/RecommendationList";
 import Link from "next/link";
 
+/**
+ * AdminSpotsPage
+ * - 추천 여행지 목록 페이지
+ * - 여행지 리스트 조회 및 새 여행지 등록 버튼 제공
+ */
+
 function AdminSpotsPage() {
   const { recommendations, loading } = useFetchRecommendations();
 

--- a/pages/admin/recommendation/new.js
+++ b/pages/admin/recommendation/new.js
@@ -3,6 +3,12 @@
 import { useAddRecommendation } from "@/hooks/recommendation/useAddRecommendation";
 import RecommendationFormContainer from "@/components/recommendation/RecommendationFormContainer";
 
+/**
+ * NewRecommendationPage
+ * - 추천 여행지 등록 폼 페이지
+ * - 여행지 정보 입력 후 등록 처리
+ */
+
 export default function NewRecommendationPage() {
   const { addRecommendation, loading } = useAddRecommendation();
 

--- a/pages/admin/reports/chats.js
+++ b/pages/admin/reports/chats.js
@@ -1,5 +1,11 @@
 import AdminChatReportsContainer from "@/components/reports/chat/AdminChatReportsContainer";
 
+/**
+ * AdminChatReportsPage
+ * - 채팅 신고 목록 페이지
+ * - 서버사이드 데이터를 컨테이너에 전달
+ */
+
 function AdminChatReportsPage(props) {
   return <AdminChatReportsContainer {...props} />;
 }

--- a/pages/admin/reports/reviews.js
+++ b/pages/admin/reports/reviews.js
@@ -1,5 +1,11 @@
 import AdminReviewReportsContainer from "@/components/reports/review/AdminReviewReportsContainer";
 
+/**
+ * AdminReviewReportsPage
+ * - 리뷰 신고 목록 페이지
+ * - 서버사이드 데이터를 컨테이너에 전달
+ */
+
 function AdminReviewReportsPage(props) {
   return <AdminReviewReportsContainer {...props} />;
 }

--- a/pages/admin/users/index.js
+++ b/pages/admin/users/index.js
@@ -1,5 +1,11 @@
 import UserTableContainer from "@/components/users/UserTableContainer";
 
+/**
+ * AdminUsersPage
+ * - 사용자 관리 테이블 페이지
+ * - 사용자 목록 및 상태 관리 기능 제공
+ */
+
 function AdminUsersPage() {
   return (
     <div className="p-6">

--- a/services/addRecommendation.js
+++ b/services/addRecommendation.js
@@ -1,6 +1,14 @@
 import { collection, addDoc, serverTimestamp } from "firebase/firestore";
 import { db } from "@/lib/firebase/client";
 
+/**
+ * Firestore에 추천 여행지 데이터를 추가합니다.
+ *
+ * @param {Object} formData - 추천 여행지 폼 데이터
+ * @param {string} imageUrl - 업로드된 이미지 URL
+ * @returns {Promise<string>} - 생성된 문서의 ID
+ */
+
 export async function addRecommendationToFirestore(formData, imageUrl) {
   const {
     name,

--- a/services/adminReports.js
+++ b/services/adminReports.js
@@ -1,3 +1,13 @@
+/**
+ * 관리자 권한으로 신고 데이터를 불러옵니다.
+ *
+ * @param {Object} params - 요청 파라미터
+ * @param {string} params.endpoint - API 엔드포인트 URL
+ * @param {string} params.token - 인증 토큰 (Bearer)
+ * @param {Object} [params.query={}] - 검색/페이징용 쿼리 파라미터
+ * @returns {Promise<Object[]>} - 신고 데이터 배열
+ */
+
 export async function getAdminReports({ endpoint, token, query = {} }) {
   const searchParams = new URLSearchParams({ limit: 50, ...query });
   const res = await fetch(`${endpoint}?${searchParams.toString()}`, {

--- a/services/deleteRecommendation.js
+++ b/services/deleteRecommendation.js
@@ -1,6 +1,13 @@
 import { deleteDoc, doc } from "firebase/firestore";
 import { db } from "@/lib/firebase/client";
 
+/**
+ * Firestore에서 추천 여행지 문서를 삭제합니다.
+ *
+ * @param {string} id - 삭제할 문서의 ID
+ * @returns {Promise<void>}
+ */
+
 export async function deleteRecommendationFromFirestore(id) {
   const ref = doc(db, "recommended_places", id);
   await deleteDoc(ref);

--- a/services/fetchRecommendations.js
+++ b/services/fetchRecommendations.js
@@ -1,6 +1,12 @@
 import { collection, getDocs, query, orderBy } from "firebase/firestore";
 import { db } from "@/lib/firebase/client";
 
+/**
+ * Firestore에서 추천 여행지 목록을 최신순으로 불러옵니다.
+ *
+ * @returns {Promise<Object[]>} - 추천 여행지 문서 배열
+ */
+
 export async function fetchRecommendationsFromFirestore() {
   const q = query(
     collection(db, "recommended_places"),

--- a/services/getRecommendationDetail.js
+++ b/services/getRecommendationDetail.js
@@ -1,6 +1,13 @@
 import { db } from "@/lib/firebase/client";
 import { doc, getDoc } from "firebase/firestore";
 
+/**
+ * 특정 추천 여행지 문서의 상세 정보를 가져옵니다.
+ *
+ * @param {string} id - 추천 여행지 문서 ID
+ * @returns {Promise<Object|null>} - 상세 정보 또는 null
+ */
+
 export async function getRecommendationDetail(id) {
   const ref = doc(db, "recommended_places", id);
   const snapshot = await getDoc(ref);

--- a/services/updateRecommendation.js
+++ b/services/updateRecommendation.js
@@ -1,6 +1,14 @@
 import { doc, updateDoc, serverTimestamp } from "firebase/firestore";
 import { db } from "@/lib/firebase/client";
 
+/**
+ * Firestore의 추천 여행지 문서를 업데이트합니다.
+ *
+ * @param {string} id - 수정할 문서의 ID
+ * @param {Object} data - 수정할 데이터
+ * @returns {Promise<void>}
+ */
+
 export async function updateRecommendationInFirestore(id, data) {
   const ref = doc(db, "recommended_places", id);
 

--- a/utils/aggregateReportsByDate.js
+++ b/utils/aggregateReportsByDate.js
@@ -1,5 +1,15 @@
 import dayjs from "dayjs";
 
+/**
+ * 일 단위로 Firestore 스냅샷 데이터를 집계합니다.
+ *
+ * @param {QuerySnapshot} snapshot - Firestore 쿼리 결과 스냅샷
+ * @param {string} field - 집계할 날짜 필드 (ex. "reportedAt")
+ * @param {Date | string} startDate - 집계를 시작할 날짜 (dayjs로 변환 가능해야 함)
+ * @param {number} [days=7] - 집계할 일수 (기본: 7일)
+ * @returns {Array<{ date: string, count: number }>} 날짜별 리포트 수 배열
+ */
+
 export function aggregateReportsByDate(snapshot, field, startDate, days = 7) {
   const countMap = {};
 

--- a/utils/aggregateReportsByMonth.js
+++ b/utils/aggregateReportsByMonth.js
@@ -1,5 +1,15 @@
 import dayjs from "dayjs";
 
+/**
+ * 월 단위로 Firestore 스냅샷 데이터를 집계합니다.
+ *
+ * @param {QuerySnapshot} snapshot - Firestore 쿼리 결과 스냅샷
+ * @param {string} field - 집계할 날짜 필드 (ex. "createdAt")
+ * @param {Date | string} startMonth - 집계를 시작할 월 (dayjs로 변환 가능해야 함)
+ * @param {number} [months=6] - 집계할 개월 수 (기본: 6개월)
+ * @returns {Array<{ month: string, count: number }>} 월별 데이터 수 배열
+ */
+
 export function aggregateReportsByMonth(
   snapshot,
   field,

--- a/utils/exportToCSV.js
+++ b/utils/exportToCSV.js
@@ -1,3 +1,10 @@
+/**
+ * 주어진 데이터 배열을 CSV 파일로 내보냅니다.
+ *
+ * @param {string} filename - 저장할 CSV 파일 이름 (확장자는 자동으로 `.csv` 붙음)
+ * @param {Array<Object>} rows - CSV로 변환할 데이터 배열 (각 객체는 동일한 키 구조여야 함)
+ */
+
 export function exportToCSV(filename, rows) {
   if (!rows || rows.length === 0) return;
 


### PR DESCRIPTION
### 주요 변경 사항

1. 인증
- 관리자 인증 컨텍스트(AdminAuthProvider)에 구조 설명 주석 추가

2. 대시보드
- AdminDashboardContainer 및 관련 시각화 컴포넌트 역할 주석 보강
- 시맨틱 구조 반영 및 데이터 흐름 명확화

3. 레이아웃
- AdminLayout, Header, Sidebar 등에 역할 주석 및 구조 설명 추가
- children 구조 및 스타일 책임 명확화

4. 추천 여행지
- 여행지 리스트/등록/수정 폼 컴포넌트에 내부 로직 주석 보강
- 관련 훅 및 서비스 함수(JS Doc) 주석 정비

5. 신고 기능
- 리뷰/채팅 신고 목록 및 상세 뷰에 컴포넌트 역할 설명 추가
- 시맨틱 구조 (section, article, dl 등) 개선

6. 사용자 관리
- 사용자 목록 테이블, 상태 뱃지, 필터 바, 검색 인풋 컴포넌트 주석 추가
- 사용자 관련 서버/Firestore 통신 함수에 JS Doc 적용

7. 공통 훅
- useFeedback, useUploadImage 훅에 내부 흐름 및 에러 처리 주석 추가

8. lib / utils
- lib/ 내부 API/DB/인증 처리 함수들 전반에 JS Doc 주석 추가
- 날짜 포맷, CSV 변환, 통계 집계 함수에 명확한 설명 주석 적용

9. 페이지 컴포넌트
- /pages/admin/ 내 주요 라우팅 페이지 파일들에 간결한 역할 주석 삽입
- 각 페이지 제목 및 연결된 컨테이너 설명 포함
