### PR TITLE
fix: 레이아웃 - 반응형 시 관리자 페이지 배경색이 좌측으로 붙는 현상 수정

### DIFF
--- a/components/layout/AdminLayout.jsx
+++ b/components/layout/AdminLayout.jsx
@@ -142,7 +142,10 @@ export default function AdminLayout({ children }) {
 
       {/* 메인 콘텐츠 영역 */}
       <div className="flex-1 flex flex-col">
-        <main className="flex-1 px-8 py-8 overflow-y-auto" role="main">
+        <main
+          className="flex-1 px-8 py-8 overflow-y-auto bg-gray-50"
+          role="main"
+        >
           {children}
         </main>
       </div>


### PR DESCRIPTION
#### 수정 내역
- AdminLayout.jsx의 메인 콘텐츠 영역 클래스 수정
className="flex-1 px-8 py-8 overflow-y-auto" → className="flex-1 px-8 py-8 overflow-y-auto bg-gray-50"
- 레이아웃 전체의 배경색 흐름이 유지되도록 보정

#### 관련 이슈

Closes #40