### PR TITLE
fix: 관리자 차트 - LineChart에 높이 div 감싸 렌더링 오류 해결

### DIFF
--- a/components/dashboard/ChatReportLineChart.jsx
+++ b/components/dashboard/ChatReportLineChart.jsx
@@ -54,7 +54,7 @@ function ChatReportLineChart({ data }) {
       <h3 className={chartHeading} id="chat-report-chart">
         💬 최근 7일 채팅 신고 추이
       </h3>
-      <div className="flex-1">
+      <div className="h-[260px]">
         <ResponsiveContainer width="100%" height="100%">
           <LineChart data={data} margin={chartMargin}>
             <CartesianGrid strokeDasharray="3 3" />

--- a/components/dashboard/ReviewReportLineChart.jsx
+++ b/components/dashboard/ReviewReportLineChart.jsx
@@ -50,7 +50,7 @@ function ReviewReportLineChart({ data }) {
       <h3 className={chartHeading} id="review-report-chart">
         📈 최근 7일 리뷰 신고 추이
       </h3>
-      <div className="flex-1">
+      <div className="h-[260px]">
         <ResponsiveContainer width="100%" height="100%">
           <LineChart data={data} margin={chartMargin}>
             <CartesianGrid strokeDasharray="3 3" />


### PR DESCRIPTION
### 수정 내역
- ChatReportLineChart, ReviewReportLineChart 컴포넌트에서 차트 내부 <ResponsiveContainer>가 높이 없는 div에 감싸져 있어 렌더링 되지 않던 문제를 해결하였습니다.
- 해결 방식: 내부를 감싸는 <div className="flex-1"> → <div className="h-[260px]">로 명시적 높이 설정
- 바 차트, 도넛 차트는 이미 명시적 height를 가지고 있어 문제 없음

⸻

### 관련 이슈

Closes #42